### PR TITLE
feat(ui): semantic card components for conversation UI redesign

### DIFF
--- a/src/components/ApiErrorCard.test.tsx
+++ b/src/components/ApiErrorCard.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ApiErrorCard } from './ApiErrorCard'
+
+describe('ApiErrorCard', () => {
+  const defaultProps = {
+    error: { code: 429, message: 'Rate limit exceeded' },
+    retryAttempt: 1,
+    maxRetries: 3,
+  }
+
+  describe('Happy path', () => {
+    it('should render error code and message', () => {
+      render(<ApiErrorCard {...defaultProps} />)
+      expect(screen.getByText(/429/)).toBeInTheDocument()
+      expect(screen.getByText(/Rate limit exceeded/)).toBeInTheDocument()
+    })
+
+    it('should render retry count when expanded', () => {
+      render(<ApiErrorCard {...defaultProps} />)
+      fireEvent.click(screen.getByRole('button'))
+      expect(screen.getByText(/1\/3/)).toBeInTheDocument()
+    })
+
+    it('should render backoff time when expanded', () => {
+      render(<ApiErrorCard {...defaultProps} retryInMs={5000} />)
+      fireEvent.click(screen.getByRole('button'))
+      expect(screen.getByText(/5000ms/)).toBeInTheDocument()
+    })
+
+    it('should have red left border styling', () => {
+      const { container } = render(<ApiErrorCard {...defaultProps} />)
+      const wrapper = container.firstElementChild as HTMLElement
+      expect(wrapper.className).toMatch(/red/)
+    })
+
+    it('should render the error icon', () => {
+      const { container } = render(<ApiErrorCard {...defaultProps} />)
+      const svg = container.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+  })
+
+  describe('Collapsible behavior', () => {
+    it('should toggle content on click', () => {
+      render(<ApiErrorCard {...defaultProps} />)
+
+      const button = screen.getByRole('button')
+      expect(button).toBeInTheDocument()
+
+      // Initially collapsed - error details not visible
+      expect(screen.queryByText(/Retry:/)).not.toBeInTheDocument()
+
+      // Click to expand
+      fireEvent.click(button)
+      expect(screen.getByText(/Retry:/)).toBeInTheDocument()
+
+      // Click to collapse
+      fireEvent.click(button)
+      expect(screen.queryByText(/Retry:/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should show "Unknown error" for empty error object', () => {
+      render(<ApiErrorCard error={{}} retryAttempt={1} maxRetries={3} />)
+      expect(screen.getByText(/Unknown error/)).toBeInTheDocument()
+    })
+
+    it('should show warning when retryAttempt exceeds maxRetries', () => {
+      render(
+        <ApiErrorCard
+          error={{ code: 500, message: 'Server error' }}
+          retryAttempt={4}
+          maxRetries={3}
+        />
+      )
+      expect(screen.getByText(/retries exhausted/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have aria-hidden on decorative icon', () => {
+      const { container } = render(<ApiErrorCard {...defaultProps} />)
+      const svg = container.querySelector('svg')
+      expect(svg?.getAttribute('aria-hidden')).toBe('true')
+    })
+
+    it('should have accessible button for collapse toggle', () => {
+      render(<ApiErrorCard {...defaultProps} />)
+      const button = screen.getByRole('button')
+      expect(button).toBeInTheDocument()
+    })
+
+    it('should be keyboard navigable', () => {
+      render(<ApiErrorCard {...defaultProps} />)
+      const button = screen.getByRole('button')
+      button.focus()
+      expect(button).toHaveFocus()
+      fireEvent.keyDown(button, { key: 'Enter' })
+      fireEvent.click(button)
+      expect(screen.getByText(/Retry:/)).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/ApiErrorCard.tsx
+++ b/src/components/ApiErrorCard.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react'
+import { AlertTriangle, ChevronRight, ChevronDown } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+interface ApiErrorCardProps {
+  error: Record<string, unknown>
+  retryAttempt: number
+  maxRetries: number
+  retryInMs?: number
+}
+
+export function ApiErrorCard({ error, retryAttempt, maxRetries, retryInMs }: ApiErrorCardProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const errorCode = error.code ?? null
+  const errorMessage = error.message ?? null
+  const hasErrorInfo = errorCode !== null || errorMessage !== null
+  const retriesExhausted = retryAttempt > maxRetries
+
+  const summaryText = hasErrorInfo
+    ? `${errorCode ? `${errorCode} — ` : ''}${errorMessage || 'Error'}`
+    : 'Unknown error'
+
+  return (
+    <div
+      className={cn(
+        'border border-gray-200 border-l-4 border-l-red-400 rounded-lg overflow-hidden bg-white my-2'
+      )}
+    >
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-red-50/50 transition-colors focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-inset"
+        aria-expanded={expanded}
+      >
+        <AlertTriangle className="w-4 h-4 text-red-500 flex-shrink-0" aria-hidden="true" />
+        <span className="text-sm font-medium text-red-700 flex-1 truncate">
+          {summaryText}
+        </span>
+        {retriesExhausted && (
+          <span className="text-xs font-medium text-red-600 bg-red-100 px-1.5 py-0.5 rounded">
+            Retries exhausted
+          </span>
+        )}
+        {expanded ? (
+          <ChevronDown className="w-4 h-4 text-red-400" aria-hidden="true" />
+        ) : (
+          <ChevronRight className="w-4 h-4 text-red-400" aria-hidden="true" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="px-3 py-2 border-t border-gray-100 bg-red-50 text-sm space-y-1">
+          {errorCode !== null && (
+            <div className="text-red-700">
+              <span className="font-medium">Code:</span> {String(errorCode)}
+            </div>
+          )}
+          {errorMessage !== null && (
+            <div className="text-red-700">
+              <span className="font-medium">Message:</span> {String(errorMessage)}
+            </div>
+          )}
+          <div className="text-red-700">
+            <span className="font-medium">Retry:</span> {retryAttempt}/{maxRetries}
+          </div>
+          {retryInMs !== undefined && (
+            <div className="text-red-700">
+              <span className="font-medium">Backoff:</span> {retryInMs}ms
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/BashProgressCard.test.tsx
+++ b/src/components/BashProgressCard.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { BashProgressCard } from './BashProgressCard'
+
+describe('BashProgressCard', () => {
+  describe('Title and status rendering', () => {
+    it('should display command with exit code and duration', () => {
+      render(
+        <BashProgressCard
+          command="npm test"
+          output="All tests passed"
+          exitCode={0}
+          duration={342}
+        />
+      )
+
+      expect(screen.getByText(/\$ npm test/)).toBeInTheDocument()
+      expect(screen.getByText(/exit 0/)).toBeInTheDocument()
+      expect(screen.getByText(/342ms/)).toBeInTheDocument()
+    })
+
+    it('should show green styling for exit code 0', () => {
+      const { container } = render(
+        <BashProgressCard command="ls" exitCode={0} />
+      )
+
+      const card = container.firstElementChild as HTMLElement
+      expect(card.className).toContain('border-l-green')
+    })
+
+    it('should show red styling for non-zero exit code', () => {
+      const { container } = render(
+        <BashProgressCard command="bad-cmd" exitCode={1} />
+      )
+
+      const card = container.firstElementChild as HTMLElement
+      expect(card.className).toContain('border-l-red')
+    })
+  })
+
+  describe('Collapsible behavior', () => {
+    it('should expand to show output on click', () => {
+      render(
+        <BashProgressCard
+          command="npm test"
+          output="All tests passed\n5 tests, 0 failures"
+          exitCode={0}
+        />
+      )
+
+      expect(screen.queryByText(/All tests passed/)).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button'))
+
+      expect(screen.getByText(/All tests passed/)).toBeInTheDocument()
+    })
+
+    it('should show "No output" when output is empty string', () => {
+      render(
+        <BashProgressCard command="touch file.txt" output="" exitCode={0} />
+      )
+
+      fireEvent.click(screen.getByRole('button'))
+
+      expect(screen.getByText('No output')).toBeInTheDocument()
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should not show exit status when exitCode is undefined', () => {
+      render(<BashProgressCard command="running..." />)
+
+      expect(screen.queryByText(/exit/)).not.toBeInTheDocument()
+    })
+
+    it('should not show duration when undefined', () => {
+      render(<BashProgressCard command="ls" exitCode={0} />)
+
+      expect(screen.queryByText(/ms/)).not.toBeInTheDocument()
+    })
+
+    it('should render with only command prop', () => {
+      const { container } = render(<BashProgressCard command="echo hello" />)
+      expect(container).toBeInTheDocument()
+      expect(screen.getByText(/\$ echo hello/)).toBeInTheDocument()
+    })
+  })
+
+  describe('ARIA and keyboard', () => {
+    it('should have ARIA label', () => {
+      render(<BashProgressCard command="npm test" exitCode={0} />)
+      expect(screen.getByRole('button', { name: /bash/i })).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/BashProgressCard.tsx
+++ b/src/components/BashProgressCard.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react'
+import { Terminal, ChevronRight, ChevronDown } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+interface BashProgressCardProps {
+  command: string
+  output?: string
+  exitCode?: number
+  duration?: number
+}
+
+export function BashProgressCard({
+  command,
+  output,
+  exitCode,
+  duration,
+}: BashProgressCardProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const isSuccess = exitCode === 0
+  const hasExitCode = exitCode !== undefined
+  const borderColor = !hasExitCode
+    ? 'border-l-gray-400'
+    : isSuccess
+      ? 'border-l-green-500'
+      : 'border-l-red-500'
+  const iconColor = !hasExitCode
+    ? 'text-gray-500'
+    : isSuccess
+      ? 'text-green-600'
+      : 'text-red-600'
+
+  const statusParts: string[] = []
+  if (hasExitCode) statusParts.push(`exit ${exitCode}`)
+  if (duration !== undefined) statusParts.push(`${duration}ms`)
+  const statusText = statusParts.length > 0 ? ` → ${statusParts.join(', ')}` : ''
+
+  const displayOutput = output === '' ? 'No output' : output
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-gray-200 border-l-4 bg-white my-2 overflow-hidden',
+        borderColor
+      )}
+    >
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-gray-50 transition-colors"
+        aria-label="Bash command"
+        aria-expanded={expanded}
+      >
+        <Terminal className={cn('w-4 h-4 flex-shrink-0', iconColor)} aria-hidden="true" />
+        <span className="text-sm font-mono text-gray-800 truncate flex-1">
+          $ {command}
+          {statusText && (
+            <span className="text-gray-500">{statusText}</span>
+          )}
+        </span>
+        {expanded ? (
+          <ChevronDown className="w-4 h-4 text-gray-400" />
+        ) : (
+          <ChevronRight className="w-4 h-4 text-gray-400" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="px-3 py-2 border-t border-gray-100 bg-gray-900">
+          <pre className="text-xs text-green-300 font-mono whitespace-pre-wrap break-all">
+            {displayOutput ?? 'No output'}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/CompactBoundaryCard.test.tsx
+++ b/src/components/CompactBoundaryCard.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CompactBoundaryCard } from './CompactBoundaryCard'
+
+describe('CompactBoundaryCard', () => {
+  describe('Happy path', () => {
+    it('should render pre and post token counts', () => {
+      render(
+        <CompactBoundaryCard
+          trigger="auto-triggered"
+          preTokens={8000}
+          postTokens={4500}
+        />
+      )
+      expect(screen.getByText(/8,000/)).toBeInTheDocument()
+      expect(screen.getByText(/4,500/)).toBeInTheDocument()
+    })
+
+    it('should render the trigger description', () => {
+      render(
+        <CompactBoundaryCard
+          trigger="auto-triggered"
+          preTokens={8000}
+          postTokens={4500}
+        />
+      )
+      expect(screen.getByText(/auto-triggered/)).toBeInTheDocument()
+    })
+
+    it('should display "Context compacted" label', () => {
+      render(
+        <CompactBoundaryCard
+          trigger="auto-triggered"
+          preTokens={8000}
+          postTokens={4500}
+        />
+      )
+      expect(screen.getByText(/Context compacted/)).toBeInTheDocument()
+    })
+
+    it('should have indigo styling', () => {
+      const { container } = render(
+        <CompactBoundaryCard trigger="manual" preTokens={5000} postTokens={2500} />
+      )
+      const wrapper = container.firstElementChild as HTMLElement
+      expect(wrapper.className).toMatch(/indigo/)
+    })
+
+    it('should render scissors icon', () => {
+      const { container } = render(
+        <CompactBoundaryCard trigger="manual" preTokens={5000} />
+      )
+      const svg = container.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should show only preTokens when postTokens is undefined', () => {
+      render(<CompactBoundaryCard trigger="auto" preTokens={8000} />)
+      expect(screen.getByText(/8,000/)).toBeInTheDocument()
+      // Should not show arrow or postTokens
+      expect(screen.queryByText(/\u2192/)).not.toBeInTheDocument()
+    })
+
+    it('should format large numbers with commas', () => {
+      render(
+        <CompactBoundaryCard
+          trigger="auto"
+          preTokens={120000}
+          postTokens={60000}
+        />
+      )
+      expect(screen.getByText(/120,000/)).toBeInTheDocument()
+      expect(screen.getByText(/60,000/)).toBeInTheDocument()
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have aria-hidden on decorative icon', () => {
+      const { container } = render(
+        <CompactBoundaryCard trigger="auto" preTokens={5000} />
+      )
+      const svg = container.querySelector('svg')
+      expect(svg?.getAttribute('aria-hidden')).toBe('true')
+    })
+
+    it('should not be collapsible (no button)', () => {
+      render(<CompactBoundaryCard trigger="auto" preTokens={5000} />)
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/CompactBoundaryCard.tsx
+++ b/src/components/CompactBoundaryCard.tsx
@@ -1,0 +1,32 @@
+import { Scissors } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+interface CompactBoundaryCardProps {
+  trigger: string
+  preTokens: number
+  postTokens?: number
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString('en-US')
+}
+
+export function CompactBoundaryCard({ trigger, preTokens, postTokens }: CompactBoundaryCardProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 my-2 px-3 py-2',
+        'border-t border-b border-indigo-300 bg-indigo-50/50'
+      )}
+    >
+      <Scissors className="w-4 h-4 text-indigo-500 flex-shrink-0" aria-hidden="true" />
+      <span className="text-sm text-indigo-700">
+        Context compacted: {formatNumber(preTokens)}
+        {postTokens !== undefined && (
+          <> {'\u2192'} {formatNumber(postTokens)}</>
+        )}
+        {' '}tokens ({trigger})
+      </span>
+    </div>
+  )
+}

--- a/src/components/ConversationThreading.test.tsx
+++ b/src/components/ConversationThreading.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MessageTyped, MAX_INDENT_LEVEL, INDENT_PX } from './MessageTyped'
+
+/** Helper to create a minimal message for testing */
+function makeMessage(overrides: Partial<{ role: string; content: string; timestamp: string }> = {}) {
+  return {
+    role: 'user' as const,
+    content: 'Hello world',
+    ...overrides,
+  }
+}
+
+describe('ConversationThreading', () => {
+  describe('indent rendering', () => {
+    it('root messages have no indent (indent=0)', () => {
+      const { container } = render(
+        <MessageTyped message={makeMessage()} indent={0} />
+      )
+      const article = container.querySelector('[role="article"]')!
+      // No paddingLeft when indent is 0
+      expect(article.getAttribute('style')).toBeNull()
+    })
+
+    it('child message has correct indent (indent=1)', () => {
+      const { container } = render(
+        <MessageTyped message={makeMessage()} indent={1} />
+      )
+      const article = container.querySelector('[role="article"]')!
+      expect(article).toHaveStyle({ paddingLeft: `${INDENT_PX}px` })
+    })
+
+    it('grandchild has double indent (indent=2)', () => {
+      const { container } = render(
+        <MessageTyped message={makeMessage()} indent={2} />
+      )
+      const article = container.querySelector('[role="article"]')!
+      expect(article).toHaveStyle({ paddingLeft: `${2 * INDENT_PX}px` })
+    })
+
+    it('maximum indent is capped at MAX_INDENT_LEVEL', () => {
+      const { container } = render(
+        <MessageTyped message={makeMessage()} indent={10} />
+      )
+      const article = container.querySelector('[role="article"]')!
+      expect(article).toHaveStyle({ paddingLeft: `${MAX_INDENT_LEVEL * INDENT_PX}px` })
+    })
+
+    it('negative indent is clamped to 0', () => {
+      const { container } = render(
+        <MessageTyped message={makeMessage()} indent={-3} />
+      )
+      const article = container.querySelector('[role="article"]')!
+      // Should behave like indent=0, no paddingLeft
+      expect(article.getAttribute('style')).toBeNull()
+    })
+  })
+
+  describe('connector line for child messages', () => {
+    it('child message renders dashed connector line', () => {
+      const { container } = render(
+        <MessageTyped message={makeMessage()} indent={1} isChildMessage />
+      )
+      const article = container.querySelector('[role="article"]')!
+      expect(article).toHaveStyle({ borderLeftStyle: 'dashed' })
+      expect(article).toHaveStyle({ borderLeftColor: '#9CA3AF' })
+    })
+
+    it('non-child message does not render dashed connector', () => {
+      const { container } = render(
+        <MessageTyped message={makeMessage()} indent={0} isChildMessage={false} />
+      )
+      const article = container.querySelector('[role="article"]')!
+      // Should not have dashed border style in inline styles
+      const style = article.getAttribute('style')
+      // style is null or does not contain 'dashed'
+      expect(style === null || !style.includes('dashed')).toBe(true)
+    })
+
+    it('child message has thread-child CSS class', () => {
+      const { container } = render(
+        <MessageTyped message={makeMessage()} indent={1} isChildMessage />
+      )
+      const article = container.querySelector('[role="article"]')!
+      expect(article.classList.contains('thread-child')).toBe(true)
+    })
+  })
+
+  describe('ARIA attributes', () => {
+    it('root message has aria-level=1', () => {
+      const { container } = render(
+        <MessageTyped message={makeMessage()} indent={0} />
+      )
+      const article = container.querySelector('[role="article"]')!
+      expect(article.getAttribute('aria-level')).toBe('1')
+    })
+
+    it('child message has aria-level=2', () => {
+      const { container } = render(
+        <MessageTyped message={makeMessage()} indent={1} />
+      )
+      const article = container.querySelector('[role="article"]')!
+      expect(article.getAttribute('aria-level')).toBe('2')
+    })
+
+    it('deeply nested message has capped aria-level', () => {
+      const { container } = render(
+        <MessageTyped message={makeMessage()} indent={10} />
+      )
+      const article = container.querySelector('[role="article"]')!
+      // Capped at MAX_INDENT_LEVEL, so aria-level = MAX_INDENT_LEVEL + 1
+      expect(article.getAttribute('aria-level')).toBe(String(MAX_INDENT_LEVEL + 1))
+    })
+
+    it('all messages have role="article"', () => {
+      const { container } = render(
+        <MessageTyped message={makeMessage()} />
+      )
+      const article = container.querySelector('[role="article"]')
+      expect(article).not.toBeNull()
+    })
+  })
+
+  describe('parentUuid prop', () => {
+    it('sets data-parent-uuid attribute when parentUuid is provided', () => {
+      const { container } = render(
+        <MessageTyped message={makeMessage()} parentUuid="abc-123" indent={1} isChildMessage />
+      )
+      const article = container.querySelector('[role="article"]')!
+      expect(article.getAttribute('data-parent-uuid')).toBe('abc-123')
+    })
+
+    it('does not set data-parent-uuid when parentUuid is not provided', () => {
+      const { container } = render(
+        <MessageTyped message={makeMessage()} />
+      )
+      const article = container.querySelector('[role="article"]')!
+      expect(article.hasAttribute('data-parent-uuid')).toBe(false)
+    })
+  })
+})

--- a/src/components/FileSnapshotCard.test.tsx
+++ b/src/components/FileSnapshotCard.test.tsx
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FileSnapshotCard } from './FileSnapshotCard'
+
+describe('FileSnapshotCard', () => {
+  describe('rendering', () => {
+    it('should show file count and timestamp', () => {
+      render(
+        <FileSnapshotCard
+          fileCount={4}
+          timestamp="14:32"
+          files={['a.ts', 'b.ts', 'c.ts', 'd.ts']}
+          isIncremental={false}
+        />
+      )
+      expect(screen.getByText(/4 files backed up at 14:32/)).toBeInTheDocument()
+    })
+
+    it('should show "incremental" label when isIncremental is true', () => {
+      render(
+        <FileSnapshotCard
+          fileCount={2}
+          timestamp="14:32"
+          files={['a.ts', 'b.ts']}
+          isIncremental={true}
+        />
+      )
+      expect(screen.getByText(/incremental/i)).toBeInTheDocument()
+    })
+
+    it('should show file list when expanded', () => {
+      render(
+        <FileSnapshotCard
+          fileCount={3}
+          timestamp="14:32"
+          files={['src/app.ts', 'src/index.ts', 'README.md']}
+          isIncremental={false}
+        />
+      )
+      // With <= 10 files, should default expanded
+      expect(screen.getByText('src/app.ts')).toBeInTheDocument()
+      expect(screen.getByText('src/index.ts')).toBeInTheDocument()
+      expect(screen.getByText('README.md')).toBeInTheDocument()
+    })
+  })
+
+  describe('visual styling', () => {
+    it('should have a blue left border', () => {
+      const { container } = render(
+        <FileSnapshotCard
+          fileCount={1}
+          timestamp="14:32"
+          files={['a.ts']}
+          isIncremental={false}
+        />
+      )
+      const card = container.firstElementChild as HTMLElement
+      expect(card.className).toMatch(/border-l/)
+      expect(card.className).toMatch(/border-l-blue-300/)
+    })
+
+    it('should render the Archive icon', () => {
+      const { container } = render(
+        <FileSnapshotCard
+          fileCount={1}
+          timestamp="14:32"
+          files={['a.ts']}
+          isIncremental={false}
+        />
+      )
+      const svg = container.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+  })
+
+  describe('collapsible behavior', () => {
+    it('should default collapsed when >10 files', () => {
+      const files = Array.from({ length: 15 }, (_, i) => `file-${i}.ts`)
+      render(
+        <FileSnapshotCard
+          fileCount={15}
+          timestamp="14:32"
+          files={files}
+          isIncremental={false}
+        />
+      )
+      // Files should NOT be visible when collapsed
+      expect(screen.queryByText('file-0.ts')).not.toBeInTheDocument()
+    })
+
+    it('should default expanded when <=10 files', () => {
+      const files = ['a.ts', 'b.ts', 'c.ts']
+      render(
+        <FileSnapshotCard
+          fileCount={3}
+          timestamp="14:32"
+          files={files}
+          isIncremental={false}
+        />
+      )
+      expect(screen.getByText('a.ts')).toBeInTheDocument()
+    })
+
+    it('should toggle file list on button click', () => {
+      const files = Array.from({ length: 15 }, (_, i) => `file-${i}.ts`)
+      render(
+        <FileSnapshotCard
+          fileCount={15}
+          timestamp="14:32"
+          files={files}
+          isIncremental={false}
+        />
+      )
+      // Initially collapsed
+      expect(screen.queryByText('file-0.ts')).not.toBeInTheDocument()
+
+      // Click to expand
+      fireEvent.click(screen.getByRole('button'))
+      expect(screen.getByText('file-0.ts')).toBeInTheDocument()
+
+      // Click to collapse
+      fireEvent.click(screen.getByRole('button'))
+      expect(screen.queryByText('file-0.ts')).not.toBeInTheDocument()
+    })
+
+    it('should be keyboard navigable (Enter key)', () => {
+      const files = Array.from({ length: 15 }, (_, i) => `file-${i}.ts`)
+      render(
+        <FileSnapshotCard
+          fileCount={15}
+          timestamp="14:32"
+          files={files}
+          isIncremental={false}
+        />
+      )
+      const button = screen.getByRole('button')
+      fireEvent.keyDown(button, { key: 'Enter' })
+      // Button's default behavior handles Enter, so we just verify it's focusable
+      expect(button).not.toHaveAttribute('tabindex', '-1')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should show "No files" when files array is empty', () => {
+      render(
+        <FileSnapshotCard
+          fileCount={0}
+          timestamp="14:32"
+          files={[]}
+          isIncremental={false}
+        />
+      )
+      expect(screen.getByText(/No files/i)).toBeInTheDocument()
+    })
+
+    it('should show "Empty snapshot" when fileCount is 0', () => {
+      render(
+        <FileSnapshotCard
+          fileCount={0}
+          timestamp="14:32"
+          files={[]}
+          isIncremental={false}
+        />
+      )
+      expect(screen.getByText(/Empty snapshot/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('should have an aria-label on the card', () => {
+      render(
+        <FileSnapshotCard
+          fileCount={3}
+          timestamp="14:32"
+          files={['a.ts', 'b.ts', 'c.ts']}
+          isIncremental={false}
+        />
+      )
+      expect(screen.getByLabelText(/file snapshot/i)).toBeInTheDocument()
+    })
+
+    it('should have aria-expanded on the collapse button', () => {
+      const files = Array.from({ length: 15 }, (_, i) => `file-${i}.ts`)
+      render(
+        <FileSnapshotCard
+          fileCount={15}
+          timestamp="14:32"
+          files={files}
+          isIncremental={false}
+        />
+      )
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('should have aria-hidden on the icon', () => {
+      const { container } = render(
+        <FileSnapshotCard
+          fileCount={1}
+          timestamp="14:32"
+          files={['a.ts']}
+          isIncremental={false}
+        />
+      )
+      const svg = container.querySelector('svg')
+      expect(svg?.getAttribute('aria-hidden')).toBe('true')
+    })
+  })
+})

--- a/src/components/FileSnapshotCard.tsx
+++ b/src/components/FileSnapshotCard.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+import { Archive, ChevronRight, ChevronDown } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+interface FileSnapshotCardProps {
+  fileCount: number
+  timestamp: string
+  files: string[]
+  isIncremental: boolean
+}
+
+export function FileSnapshotCard({
+  fileCount,
+  timestamp,
+  files,
+  isIncremental,
+}: FileSnapshotCardProps) {
+  const isEmpty = fileCount === 0 && files.length === 0
+  const defaultExpanded = files.length > 0 && files.length <= 10
+  const [expanded, setExpanded] = useState(defaultExpanded)
+
+  if (isEmpty) {
+    return (
+      <div
+        className={cn(
+          'rounded-lg border border-gray-200 border-l-4 border-l-blue-300 bg-blue-50 p-3 my-2'
+        )}
+        aria-label="File snapshot"
+      >
+        <div className="flex items-start gap-2">
+          <Archive
+            className="w-4 h-4 text-blue-500 mt-0.5 flex-shrink-0"
+            aria-hidden="true"
+          />
+          <div className="text-sm text-blue-700">
+            Empty snapshot — No files
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const headerText = `${fileCount} file${fileCount !== 1 ? 's' : ''} backed up at ${timestamp}`
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-gray-200 border-l-4 border-l-blue-300 overflow-hidden bg-white my-2'
+      )}
+      aria-label="File snapshot"
+    >
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-left bg-blue-50 hover:bg-blue-100 transition-colors"
+        aria-expanded={expanded}
+      >
+        <Archive
+          className="w-4 h-4 text-blue-500 flex-shrink-0"
+          aria-hidden="true"
+        />
+        <span className="text-sm text-blue-700 flex-1">
+          {headerText}
+          {isIncremental && (
+            <span className="ml-2 text-xs text-blue-500 font-medium">
+              (incremental)
+            </span>
+          )}
+        </span>
+        {expanded ? (
+          <ChevronDown className="w-4 h-4 text-blue-400" />
+        ) : (
+          <ChevronRight className="w-4 h-4 text-blue-400" />
+        )}
+      </button>
+      {expanded && (
+        <div className="px-3 py-2 border-t border-blue-100 bg-white">
+          <ul className="text-xs text-gray-600 space-y-0.5">
+            {files.map((file, i) => (
+              <li key={i} className="font-mono truncate">
+                {file}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/HookProgressCard.test.tsx
+++ b/src/components/HookProgressCard.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { HookProgressCard } from './HookProgressCard'
+
+describe('HookProgressCard', () => {
+  describe('Title and status rendering', () => {
+    it('should display hook event and command name', () => {
+      render(
+        <HookProgressCard
+          hookEvent="SessionStart"
+          hookName="pre-session"
+          command="setup-env.sh"
+        />
+      )
+
+      expect(screen.getByText(/Hook: SessionStart/)).toBeInTheDocument()
+      expect(screen.getByText(/setup-env\.sh/)).toBeInTheDocument()
+    })
+
+    it('should have amber left border', () => {
+      const { container } = render(
+        <HookProgressCard
+          hookEvent="SessionStart"
+          hookName="pre-session"
+          command="cmd"
+        />
+      )
+
+      const card = container.firstElementChild as HTMLElement
+      expect(card.className).toContain('border-l-amber')
+    })
+  })
+
+  describe('Collapsible behavior', () => {
+    it('should expand to show output on click when output exists', () => {
+      render(
+        <HookProgressCard
+          hookEvent="SessionStart"
+          hookName="pre-session"
+          command="setup.sh"
+          output="Environment configured successfully"
+        />
+      )
+
+      expect(screen.queryByText(/Environment configured/)).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button'))
+
+      expect(screen.getByText(/Environment configured successfully/)).toBeInTheDocument()
+    })
+
+    it('should not be expandable when output is undefined', () => {
+      render(
+        <HookProgressCard
+          hookEvent="SessionStart"
+          hookName="pre-session"
+          command="setup.sh"
+        />
+      )
+
+      // No chevron/expand indicator when no output
+      expect(screen.queryByTestId('hook-expand-icon')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('ARIA and keyboard', () => {
+    it('should have ARIA label', () => {
+      render(
+        <HookProgressCard
+          hookEvent="SessionStart"
+          hookName="pre-session"
+          command="cmd"
+          output="some output"
+        />
+      )
+
+      expect(screen.getByRole('button', { name: /hook/i })).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/HookProgressCard.tsx
+++ b/src/components/HookProgressCard.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+import { GitBranch, ChevronRight, ChevronDown } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+interface HookProgressCardProps {
+  hookEvent: string
+  hookName: string
+  command: string
+  output?: string
+}
+
+export function HookProgressCard({
+  hookEvent,
+  hookName,
+  command,
+  output,
+}: HookProgressCardProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const hasOutput = output !== undefined
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-amber-200 border-l-4 border-l-amber-400 bg-amber-50 my-2 overflow-hidden'
+      )}
+    >
+      {hasOutput ? (
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-amber-100 transition-colors"
+          aria-label="Hook event"
+          aria-expanded={expanded}
+        >
+          <GitBranch className="w-4 h-4 text-amber-600 flex-shrink-0" aria-hidden="true" />
+          <span className="text-sm text-amber-900 truncate flex-1">
+            Hook: {hookEvent} → {command}
+          </span>
+          {expanded ? (
+            <ChevronDown className="w-4 h-4 text-amber-400" data-testid="hook-expand-icon" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-amber-400" data-testid="hook-expand-icon" />
+          )}
+        </button>
+      ) : (
+        <div className="flex items-center gap-2 px-3 py-2">
+          <GitBranch className="w-4 h-4 text-amber-600 flex-shrink-0" aria-hidden="true" />
+          <span className="text-sm text-amber-900 truncate flex-1">
+            Hook: {hookEvent} → {command}
+          </span>
+        </div>
+      )}
+
+      {expanded && hasOutput && (
+        <div className="px-3 py-2 border-t border-amber-100 bg-amber-50/50">
+          <pre className="text-xs text-amber-800 font-mono whitespace-pre-wrap break-all">
+            {output}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/HookSummaryCard.test.tsx
+++ b/src/components/HookSummaryCard.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { HookSummaryCard } from './HookSummaryCard'
+
+describe('HookSummaryCard', () => {
+  const defaultProps = {
+    hookCount: 4,
+    hookInfos: ['pre-commit', 'lint', 'format', 'test'],
+  }
+
+  describe('Happy path', () => {
+    it('should render hook count', () => {
+      render(<HookSummaryCard {...defaultProps} />)
+      expect(screen.getByText(/4 hooks executed/)).toBeInTheDocument()
+    })
+
+    it('should show error count when hookErrors provided', () => {
+      render(
+        <HookSummaryCard
+          {...defaultProps}
+          hookErrors={['lint failed']}
+        />
+      )
+      expect(screen.getByText(/1 error/)).toBeInTheDocument()
+    })
+
+    it('should have amber left border styling', () => {
+      const { container } = render(<HookSummaryCard {...defaultProps} />)
+      const wrapper = container.firstElementChild as HTMLElement
+      expect(wrapper.className).toMatch(/amber/)
+    })
+
+    it('should render the hook icon', () => {
+      const { container } = render(<HookSummaryCard {...defaultProps} />)
+      const svg = container.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+
+    it('should display duration when provided', () => {
+      render(<HookSummaryCard {...defaultProps} durationMs={350} />)
+      expect(screen.getByText(/350ms/)).toBeInTheDocument()
+    })
+
+    it('should show prevented continuation warning', () => {
+      render(
+        <HookSummaryCard
+          {...defaultProps}
+          preventedContinuation={true}
+        />
+      )
+      expect(screen.getByText(/prevented continuation/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('Collapsible behavior', () => {
+    it('should toggle hook list on click', () => {
+      render(<HookSummaryCard {...defaultProps} />)
+
+      const button = screen.getByRole('button')
+
+      // Initially collapsed
+      expect(screen.queryByText('pre-commit')).not.toBeInTheDocument()
+
+      // Expand
+      fireEvent.click(button)
+      expect(screen.getByText('pre-commit')).toBeInTheDocument()
+      expect(screen.getByText('lint')).toBeInTheDocument()
+      expect(screen.getByText('format')).toBeInTheDocument()
+      expect(screen.getByText('test')).toBeInTheDocument()
+
+      // Collapse
+      fireEvent.click(button)
+      expect(screen.queryByText('pre-commit')).not.toBeInTheDocument()
+    })
+
+    it('should show hook errors when expanded', () => {
+      render(
+        <HookSummaryCard
+          {...defaultProps}
+          hookErrors={['lint failed', 'test timeout']}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button'))
+      expect(screen.getByText('lint failed')).toBeInTheDocument()
+      expect(screen.getByText('test timeout')).toBeInTheDocument()
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should show "No hooks" for empty hookInfos', () => {
+      render(<HookSummaryCard hookCount={0} hookInfos={[]} />)
+      expect(screen.getByText(/No hooks/)).toBeInTheDocument()
+    })
+
+    it('should handle undefined hookErrors', () => {
+      const { container } = render(<HookSummaryCard {...defaultProps} />)
+      expect(container).toBeInTheDocument()
+    })
+
+    it('should handle undefined durationMs', () => {
+      const { container } = render(<HookSummaryCard {...defaultProps} />)
+      expect(container).toBeInTheDocument()
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have aria-hidden on decorative icon', () => {
+      const { container } = render(<HookSummaryCard {...defaultProps} />)
+      const svg = container.querySelector('svg')
+      expect(svg?.getAttribute('aria-hidden')).toBe('true')
+    })
+
+    it('should have accessible button for collapse toggle', () => {
+      render(<HookSummaryCard {...defaultProps} />)
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('should be keyboard navigable', () => {
+      render(<HookSummaryCard {...defaultProps} />)
+      const button = screen.getByRole('button')
+      button.focus()
+      expect(button).toHaveFocus()
+      fireEvent.keyDown(button, { key: 'Enter' })
+      fireEvent.click(button)
+      expect(screen.getByText('pre-commit')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/HookSummaryCard.tsx
+++ b/src/components/HookSummaryCard.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+import { GitBranch, ChevronRight, ChevronDown } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+interface HookSummaryCardProps {
+  hookCount: number
+  hookInfos: string[]
+  hookErrors?: string[]
+  durationMs?: number
+  preventedContinuation?: boolean
+}
+
+export function HookSummaryCard({
+  hookCount,
+  hookInfos,
+  hookErrors,
+  durationMs,
+  preventedContinuation,
+}: HookSummaryCardProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const errorCount = hookErrors?.length ?? 0
+  const isEmpty = hookInfos.length === 0
+
+  const summaryParts: string[] = []
+  if (isEmpty) {
+    summaryParts.push('No hooks')
+  } else {
+    summaryParts.push(`${hookCount} hooks executed`)
+    if (errorCount > 0) {
+      summaryParts.push(`(${errorCount} error${errorCount > 1 ? 's' : ''})`)
+    }
+  }
+  if (durationMs !== undefined) {
+    summaryParts.push(`in ${durationMs}ms`)
+  }
+
+  return (
+    <div
+      className={cn(
+        'border border-gray-200 border-l-4 border-l-amber-300 rounded-lg overflow-hidden bg-white my-2'
+      )}
+    >
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-amber-50/50 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-300 focus:ring-inset"
+        aria-expanded={expanded}
+      >
+        <GitBranch className="w-4 h-4 text-amber-600 flex-shrink-0" aria-hidden="true" />
+        <span className="text-sm font-medium text-amber-800 flex-1">
+          {summaryParts.join(' ')}
+        </span>
+        {preventedContinuation && (
+          <span className="text-xs font-medium text-amber-700 bg-amber-100 px-1.5 py-0.5 rounded">
+            Prevented continuation
+          </span>
+        )}
+        {expanded ? (
+          <ChevronDown className="w-4 h-4 text-amber-500" aria-hidden="true" />
+        ) : (
+          <ChevronRight className="w-4 h-4 text-amber-500" aria-hidden="true" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="px-3 py-2 border-t border-gray-100 bg-amber-50/30 text-sm space-y-2">
+          {hookInfos.length > 0 && (
+            <ul className="list-disc pl-4 space-y-0.5 text-amber-800">
+              {hookInfos.map((hook, i) => (
+                <li key={i}>{hook}</li>
+              ))}
+            </ul>
+          )}
+          {hookErrors && hookErrors.length > 0 && (
+            <div>
+              <p className="text-xs text-red-600 font-medium mb-1">Errors:</p>
+              <ul className="list-disc pl-4 space-y-0.5 text-red-600">
+                {hookErrors.map((err, i) => (
+                  <li key={i}>{err}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/LocalCommandEventCard.test.tsx
+++ b/src/components/LocalCommandEventCard.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LocalCommandEventCard } from './LocalCommandEventCard'
+
+describe('LocalCommandEventCard', () => {
+  describe('Happy path', () => {
+    it('should render command content', () => {
+      render(<LocalCommandEventCard content="git status" />)
+      expect(screen.getByText('git status')).toBeInTheDocument()
+    })
+
+    it('should render terminal icon', () => {
+      const { container } = render(<LocalCommandEventCard content="ls -la" />)
+      const svg = container.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+
+    it('should have gray text styling', () => {
+      const { container } = render(<LocalCommandEventCard content="pwd" />)
+      const wrapper = container.firstElementChild as HTMLElement
+      expect(wrapper.className).toMatch(/gray/)
+    })
+
+    it('should render as single-line event', () => {
+      render(<LocalCommandEventCard content="npm install" />)
+      // Should not have a button (not collapsible)
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should render nothing for empty content', () => {
+      const { container } = render(<LocalCommandEventCard content="" />)
+      expect(container.firstElementChild).toBeNull()
+    })
+
+    it('should render nothing for whitespace-only content', () => {
+      const { container } = render(<LocalCommandEventCard content="   " />)
+      expect(container.firstElementChild).toBeNull()
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have aria-hidden on decorative icon', () => {
+      const { container } = render(<LocalCommandEventCard content="echo hello" />)
+      const svg = container.querySelector('svg')
+      expect(svg?.getAttribute('aria-hidden')).toBe('true')
+    })
+
+    it('should not be collapsible (no button)', () => {
+      render(<LocalCommandEventCard content="echo hello" />)
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/LocalCommandEventCard.tsx
+++ b/src/components/LocalCommandEventCard.tsx
@@ -1,0 +1,23 @@
+import { Terminal } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+interface LocalCommandEventCardProps {
+  content: string
+}
+
+export function LocalCommandEventCard({ content }: LocalCommandEventCardProps) {
+  if (!content || !content.trim()) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 my-1 px-3 py-1.5 text-gray-500'
+      )}
+    >
+      <Terminal className="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
+      <span className="text-sm">{content}</span>
+    </div>
+  )
+}

--- a/src/components/McpProgressCard.test.tsx
+++ b/src/components/McpProgressCard.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { McpProgressCard } from './McpProgressCard'
+
+describe('McpProgressCard', () => {
+  describe('Title and status rendering', () => {
+    it('should display server.method with params', () => {
+      render(
+        <McpProgressCard
+          server="filesystem"
+          method="readFile"
+          params={{ path: '/tmp/test.txt' }}
+        />
+      )
+
+      expect(screen.getByText(/MCP: filesystem\.readFile/)).toBeInTheDocument()
+    })
+
+    it('should show "(no params)" when params is undefined', () => {
+      render(
+        <McpProgressCard server="memory" method="search" />
+      )
+
+      expect(screen.getByText(/\(no params\)/)).toBeInTheDocument()
+    })
+
+    it('should have purple left border', () => {
+      const { container } = render(
+        <McpProgressCard server="fs" method="read" />
+      )
+
+      const card = container.firstElementChild as HTMLElement
+      expect(card.className).toContain('border-l-purple')
+    })
+  })
+
+  describe('Collapsible behavior', () => {
+    it('should expand to show result on click', () => {
+      render(
+        <McpProgressCard
+          server="filesystem"
+          method="readFile"
+          params={{ path: '/tmp/test.txt' }}
+          result={{ content: 'file contents here' }}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button'))
+
+      expect(screen.getByText(/file contents here/)).toBeInTheDocument()
+    })
+
+    it('should show params in expanded view', () => {
+      render(
+        <McpProgressCard
+          server="fs"
+          method="read"
+          params={{ path: '/tmp/test.txt' }}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button'))
+
+      expect(screen.getByText(/\/tmp\/test\.txt/)).toBeInTheDocument()
+    })
+  })
+
+  describe('ARIA and keyboard', () => {
+    it('should have ARIA label', () => {
+      render(<McpProgressCard server="fs" method="read" />)
+      expect(screen.getByRole('button', { name: /mcp/i })).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/McpProgressCard.tsx
+++ b/src/components/McpProgressCard.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+import { Plug, ChevronRight, ChevronDown } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+interface McpProgressCardProps {
+  server: string
+  method: string
+  params?: object
+  result?: object
+}
+
+export function McpProgressCard({
+  server,
+  method,
+  params,
+  result,
+}: McpProgressCardProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const paramsLabel = params ? '' : ' (no params)'
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-purple-200 border-l-4 border-l-purple-400 bg-purple-50 my-2 overflow-hidden'
+      )}
+    >
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-purple-100 transition-colors"
+        aria-label="MCP tool call"
+        aria-expanded={expanded}
+      >
+        <Plug className="w-4 h-4 text-purple-600 flex-shrink-0" aria-hidden="true" />
+        <span className="text-sm text-purple-900 truncate flex-1">
+          MCP: {server}.{method}{paramsLabel}
+        </span>
+        {expanded ? (
+          <ChevronDown className="w-4 h-4 text-purple-400" />
+        ) : (
+          <ChevronRight className="w-4 h-4 text-purple-400" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="px-3 py-2 border-t border-purple-100 bg-purple-50/50 space-y-2">
+          {params && (
+            <div>
+              <div className="text-xs font-medium text-purple-700 mb-1">Params:</div>
+              <pre className="text-xs text-purple-800 font-mono whitespace-pre-wrap break-all">
+                {JSON.stringify(params, null, 2)}
+              </pre>
+            </div>
+          )}
+          {result && (
+            <div>
+              <div className="text-xs font-medium text-purple-700 mb-1">Result:</div>
+              <pre className="text-xs text-purple-800 font-mono whitespace-pre-wrap break-all">
+                {JSON.stringify(result, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/MessageQueueEventCard.test.tsx
+++ b/src/components/MessageQueueEventCard.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MessageQueueEventCard } from './MessageQueueEventCard'
+
+describe('MessageQueueEventCard', () => {
+  describe('rendering', () => {
+    it('should render enqueue operation with timestamp', () => {
+      render(
+        <MessageQueueEventCard operation="enqueue" timestamp="14:32:15" />
+      )
+      expect(screen.getByText(/Message enqueued at 14:32:15/)).toBeInTheDocument()
+    })
+
+    it('should render dequeue operation as "Message processed"', () => {
+      render(
+        <MessageQueueEventCard operation="dequeue" timestamp="14:32:15" />
+      )
+      expect(screen.getByText(/Message processed/)).toBeInTheDocument()
+    })
+
+    it('should show content preview when provided', () => {
+      render(
+        <MessageQueueEventCard
+          operation="enqueue"
+          timestamp="14:32:15"
+          content="Hello world"
+        />
+      )
+      expect(screen.getByText(/Hello world/)).toBeInTheDocument()
+    })
+
+    it('should show queueId when provided', () => {
+      render(
+        <MessageQueueEventCard
+          operation="enqueue"
+          timestamp="14:32:15"
+          queueId="queue-abc-123"
+        />
+      )
+      expect(screen.getByText(/queue-abc-123/)).toBeInTheDocument()
+    })
+  })
+
+  describe('visual styling', () => {
+    it('should have a gray left border', () => {
+      const { container } = render(
+        <MessageQueueEventCard operation="enqueue" timestamp="14:32:15" />
+      )
+      const card = container.firstElementChild as HTMLElement
+      expect(card.className).toMatch(/border-l/)
+      expect(card.className).toMatch(/border-l-gray-300/)
+    })
+
+    it('should render the ListOrdered icon', () => {
+      const { container } = render(
+        <MessageQueueEventCard operation="enqueue" timestamp="14:32:15" />
+      )
+      const svg = container.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+  })
+
+  describe('no collapse behavior', () => {
+    it('should not have a collapse button', () => {
+      render(
+        <MessageQueueEventCard operation="enqueue" timestamp="14:32:15" />
+      )
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should render without content (no preview shown)', () => {
+      const { container } = render(
+        <MessageQueueEventCard operation="enqueue" timestamp="14:32:15" />
+      )
+      expect(container.firstElementChild).toBeInTheDocument()
+    })
+
+    it('should render with empty content string', () => {
+      const { container } = render(
+        <MessageQueueEventCard
+          operation="enqueue"
+          timestamp="14:32:15"
+          content=""
+        />
+      )
+      expect(container.firstElementChild).toBeInTheDocument()
+    })
+
+    it('should render without timestamp (no time shown)', () => {
+      render(
+        <MessageQueueEventCard operation="enqueue" timestamp="" />
+      )
+      // Should show operation text but not "at" with timestamp
+      expect(screen.getByText(/Message enqueued/)).toBeInTheDocument()
+      expect(screen.queryByText(/at\s*$/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('should have an aria-label on the card', () => {
+      render(
+        <MessageQueueEventCard operation="enqueue" timestamp="14:32:15" />
+      )
+      expect(screen.getByLabelText(/message queue event/i)).toBeInTheDocument()
+    })
+
+    it('should have aria-hidden on the icon', () => {
+      const { container } = render(
+        <MessageQueueEventCard operation="enqueue" timestamp="14:32:15" />
+      )
+      const svg = container.querySelector('svg')
+      expect(svg?.getAttribute('aria-hidden')).toBe('true')
+    })
+  })
+})

--- a/src/components/MessageQueueEventCard.tsx
+++ b/src/components/MessageQueueEventCard.tsx
@@ -1,0 +1,52 @@
+import { ListOrdered } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+interface MessageQueueEventCardProps {
+  operation: 'enqueue' | 'dequeue'
+  timestamp: string
+  content?: string
+  queueId?: string
+}
+
+export function MessageQueueEventCard({
+  operation,
+  timestamp,
+  content,
+  queueId,
+}: MessageQueueEventCardProps) {
+  const messageText =
+    operation === 'dequeue'
+      ? 'Message processed'
+      : timestamp
+        ? `Message enqueued at ${timestamp}`
+        : 'Message enqueued'
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-gray-200 border-l-4 border-l-gray-300 bg-white p-3 my-2'
+      )}
+      aria-label="Message queue event"
+    >
+      <div className="flex items-start gap-2">
+        <ListOrdered
+          className="w-4 h-4 text-gray-500 mt-0.5 flex-shrink-0"
+          aria-hidden="true"
+        />
+        <div className="flex-1 min-w-0">
+          <div className="text-sm text-gray-700">{messageText}</div>
+          {queueId && (
+            <div className="text-xs text-gray-500 mt-1">
+              Queue: {queueId}
+            </div>
+          )}
+          {content && content.length > 0 && (
+            <div className="text-xs text-gray-500 mt-1 truncate">
+              {content}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/MessageTyped.test.tsx
+++ b/src/components/MessageTyped.test.tsx
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MessageTyped } from './MessageTyped'
+import type { Message as MessageType } from '../hooks/use-session'
+
+// Mock all card components so we can verify dispatch without needing their internals
+vi.mock('./TurnDurationCard', () => ({
+  TurnDurationCard: (props: any) => <div data-testid="turn-duration-card" data-props={JSON.stringify(props)} />
+}))
+vi.mock('./ApiErrorCard', () => ({
+  ApiErrorCard: (props: any) => <div data-testid="api-error-card" data-props={JSON.stringify(props)} />
+}))
+vi.mock('./CompactBoundaryCard', () => ({
+  CompactBoundaryCard: (props: any) => <div data-testid="compact-boundary-card" data-props={JSON.stringify(props)} />
+}))
+vi.mock('./HookSummaryCard', () => ({
+  HookSummaryCard: (props: any) => <div data-testid="hook-summary-card" data-props={JSON.stringify(props)} />
+}))
+vi.mock('./LocalCommandEventCard', () => ({
+  LocalCommandEventCard: (props: any) => <div data-testid="local-command-card" data-props={JSON.stringify(props)} />
+}))
+vi.mock('./AgentProgressCard', () => ({
+  AgentProgressCard: (props: any) => <div data-testid="agent-progress-card" data-props={JSON.stringify(props)} />
+}))
+vi.mock('./BashProgressCard', () => ({
+  BashProgressCard: (props: any) => <div data-testid="bash-progress-card" data-props={JSON.stringify(props)} />
+}))
+vi.mock('./HookProgressCard', () => ({
+  HookProgressCard: (props: any) => <div data-testid="hook-progress-card" data-props={JSON.stringify(props)} />
+}))
+vi.mock('./McpProgressCard', () => ({
+  McpProgressCard: (props: any) => <div data-testid="mcp-progress-card" data-props={JSON.stringify(props)} />
+}))
+vi.mock('./TaskQueueCard', () => ({
+  TaskQueueCard: (props: any) => <div data-testid="task-queue-card" data-props={JSON.stringify(props)} />
+}))
+
+function makeMessage(overrides: Partial<MessageType> = {}): MessageType {
+  return {
+    role: 'system',
+    content: '',
+    timestamp: '2026-01-30T12:00:00Z',
+    ...overrides,
+  } as MessageType
+}
+
+describe('MessageTyped dispatch', () => {
+  describe('System event subtypes', () => {
+    it('dispatches turn_duration to TurnDurationCard', () => {
+      render(
+        <MessageTyped
+          message={makeMessage()}
+          messageType="system"
+          metadata={{ type: 'turn_duration', durationMs: 500, startTime: '10:00', endTime: '10:01' }}
+        />
+      )
+      expect(screen.getByTestId('turn-duration-card')).toBeInTheDocument()
+    })
+
+    it('dispatches api_error to ApiErrorCard', () => {
+      render(
+        <MessageTyped
+          message={makeMessage()}
+          messageType="system"
+          metadata={{ type: 'api_error', error: { code: 500 }, retryAttempt: 1, maxRetries: 3 }}
+        />
+      )
+      expect(screen.getByTestId('api-error-card')).toBeInTheDocument()
+    })
+
+    it('dispatches compact_boundary to CompactBoundaryCard', () => {
+      render(
+        <MessageTyped
+          message={makeMessage()}
+          messageType="system"
+          metadata={{ type: 'compact_boundary', trigger: 'auto', preTokens: 1000 }}
+        />
+      )
+      expect(screen.getByTestId('compact-boundary-card')).toBeInTheDocument()
+    })
+
+    it('dispatches hook_summary to HookSummaryCard', () => {
+      render(
+        <MessageTyped
+          message={makeMessage()}
+          messageType="system"
+          metadata={{ type: 'hook_summary', hookCount: 2, hookInfos: [] }}
+        />
+      )
+      expect(screen.getByTestId('hook-summary-card')).toBeInTheDocument()
+    })
+
+    it('dispatches local_command to LocalCommandEventCard', () => {
+      render(
+        <MessageTyped
+          message={makeMessage()}
+          messageType="system"
+          metadata={{ type: 'local_command', content: 'ls -la' }}
+        />
+      )
+      expect(screen.getByTestId('local-command-card')).toBeInTheDocument()
+    })
+
+    it('uses metadata.subtype as fallback for system events', () => {
+      render(
+        <MessageTyped
+          message={makeMessage()}
+          messageType="system"
+          metadata={{ subtype: 'turn_duration', durationMs: 100 }}
+        />
+      )
+      expect(screen.getByTestId('turn-duration-card')).toBeInTheDocument()
+    })
+
+    it('falls back to SystemMetadataCard for unknown system subtype', () => {
+      const { container } = render(
+        <MessageTyped
+          message={makeMessage()}
+          messageType="system"
+          metadata={{ type: 'unknown_system_event', someData: 'test' }}
+        />
+      )
+      // Should NOT render any specialized card
+      expect(screen.queryByTestId('turn-duration-card')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('api-error-card')).not.toBeInTheDocument()
+      // SystemMetadataCard renders metadata keys; check for "someData"
+      expect(container.textContent).toContain('someData')
+    })
+
+    it('falls back to SystemMetadataCard when no subtype is present', () => {
+      const { container } = render(
+        <MessageTyped
+          message={makeMessage()}
+          messageType="system"
+          metadata={{ customField: 'value123' }}
+        />
+      )
+      expect(container.textContent).toContain('customField')
+      expect(container.textContent).toContain('value123')
+    })
+  })
+
+  describe('Progress event subtypes', () => {
+    it('dispatches agent_progress to AgentProgressCard', () => {
+      render(
+        <MessageTyped
+          message={makeMessage()}
+          messageType="progress"
+          metadata={{ type: 'agent_progress', agentId: 'a1', prompt: 'test', model: 'opus' }}
+        />
+      )
+      expect(screen.getByTestId('agent-progress-card')).toBeInTheDocument()
+    })
+
+    it('dispatches bash_progress to BashProgressCard', () => {
+      render(
+        <MessageTyped
+          message={makeMessage()}
+          messageType="progress"
+          metadata={{ type: 'bash_progress', command: 'echo hi' }}
+        />
+      )
+      expect(screen.getByTestId('bash-progress-card')).toBeInTheDocument()
+    })
+
+    it('dispatches hook_progress to HookProgressCard', () => {
+      render(
+        <MessageTyped
+          message={makeMessage()}
+          messageType="progress"
+          metadata={{ type: 'hook_progress', hookEvent: 'pre-commit', hookName: 'lint', command: 'eslint .' }}
+        />
+      )
+      expect(screen.getByTestId('hook-progress-card')).toBeInTheDocument()
+    })
+
+    it('dispatches mcp_progress to McpProgressCard', () => {
+      render(
+        <MessageTyped
+          message={makeMessage()}
+          messageType="progress"
+          metadata={{ type: 'mcp_progress', server: 'supabase', method: 'query' }}
+        />
+      )
+      expect(screen.getByTestId('mcp-progress-card')).toBeInTheDocument()
+    })
+
+    it('dispatches waiting_for_task to TaskQueueCard', () => {
+      render(
+        <MessageTyped
+          message={makeMessage()}
+          messageType="progress"
+          metadata={{ type: 'waiting_for_task', position: 3, queueLength: 10 }}
+        />
+      )
+      expect(screen.getByTestId('task-queue-card')).toBeInTheDocument()
+    })
+
+    it('falls back to SystemMetadataCard for unknown progress subtype', () => {
+      const { container } = render(
+        <MessageTyped
+          message={makeMessage()}
+          messageType="progress"
+          metadata={{ type: 'unknown_progress', detail: 'xyz' }}
+        />
+      )
+      expect(screen.queryByTestId('agent-progress-card')).not.toBeInTheDocument()
+      expect(container.textContent).toContain('detail')
+    })
+  })
+
+  describe('Non-system/progress types pass through', () => {
+    it('renders assistant message content normally', () => {
+      render(
+        <MessageTyped
+          message={makeMessage({ role: 'assistant', content: 'Hello world' })}
+          messageType="assistant"
+        />
+      )
+      expect(screen.getByText('Hello world')).toBeInTheDocument()
+    })
+
+    it('renders user message content normally', () => {
+      render(
+        <MessageTyped
+          message={makeMessage({ role: 'user', content: 'My question' })}
+          messageType="user"
+        />
+      )
+      expect(screen.getByText('My question')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/SessionSummaryCard.test.tsx
+++ b/src/components/SessionSummaryCard.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SessionSummaryCard } from './SessionSummaryCard'
+
+describe('SessionSummaryCard', () => {
+  describe('rendering', () => {
+    it('should show truncated summary (first 150 chars) when collapsed', () => {
+      const summary = 'A'.repeat(200)
+      render(
+        <SessionSummaryCard
+          summary={summary}
+          leafUuid="uuid-123"
+          wordCount={50}
+        />
+      )
+      // Should show truncated text with ellipsis
+      expect(screen.getByText(/Session summary:/)).toBeInTheDocument()
+      // The displayed text should end with "..." and be shorter than full summary
+      const displayed = summary.slice(0, 150) + '...'
+      expect(screen.getByText(displayed)).toBeInTheDocument()
+    })
+
+    it('should show short summary without truncation', () => {
+      render(
+        <SessionSummaryCard
+          summary="Short summary text"
+          leafUuid="uuid-123"
+          wordCount={3}
+        />
+      )
+      expect(screen.getByText(/Short summary text/)).toBeInTheDocument()
+    })
+
+    it('should show word count', () => {
+      render(
+        <SessionSummaryCard
+          summary="Some summary"
+          leafUuid="uuid-123"
+          wordCount={42}
+        />
+      )
+      expect(screen.getByText(/42 words/)).toBeInTheDocument()
+    })
+  })
+
+  describe('visual styling', () => {
+    it('should have a rose left border', () => {
+      const { container } = render(
+        <SessionSummaryCard
+          summary="Test summary"
+          leafUuid="uuid-123"
+          wordCount={10}
+        />
+      )
+      const card = container.firstElementChild as HTMLElement
+      expect(card.className).toMatch(/border-l/)
+      expect(card.className).toMatch(/border-l-rose-300/)
+    })
+
+    it('should render the BookOpen icon', () => {
+      const { container } = render(
+        <SessionSummaryCard
+          summary="Test summary"
+          leafUuid="uuid-123"
+          wordCount={10}
+        />
+      )
+      const svg = container.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+  })
+
+  describe('collapsible behavior', () => {
+    it('should expand to show full summary on click', () => {
+      const summary = 'Word '.repeat(100).trim()
+      render(
+        <SessionSummaryCard
+          summary={summary}
+          leafUuid="uuid-123"
+          wordCount={100}
+        />
+      )
+      // Click to expand
+      fireEvent.click(screen.getByRole('button'))
+      // Full summary should now be visible
+      expect(screen.getByText(summary)).toBeInTheDocument()
+    })
+
+    it('should toggle between collapsed and expanded', () => {
+      const summary = 'X'.repeat(200)
+      render(
+        <SessionSummaryCard
+          summary={summary}
+          leafUuid="uuid-123"
+          wordCount={50}
+        />
+      )
+      const button = screen.getByRole('button')
+
+      // Expand
+      fireEvent.click(button)
+      expect(screen.getByText(summary)).toBeInTheDocument()
+
+      // Collapse
+      fireEvent.click(button)
+      // Full text should no longer be displayed
+      expect(screen.queryByText(summary)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should show "No summary available" when summary is empty', () => {
+      render(
+        <SessionSummaryCard
+          summary=""
+          leafUuid="uuid-123"
+          wordCount={0}
+        />
+      )
+      expect(screen.getByText(/No summary available/i)).toBeInTheDocument()
+    })
+
+    it('should handle very long summary in collapsed state', () => {
+      const summary = 'LongWord '.repeat(500).trim()
+      const { container } = render(
+        <SessionSummaryCard
+          summary={summary}
+          leafUuid="uuid-123"
+          wordCount={500}
+        />
+      )
+      // Should render without crashing
+      expect(container.firstElementChild).toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('should have an aria-label on the card', () => {
+      render(
+        <SessionSummaryCard
+          summary="Test summary"
+          leafUuid="uuid-123"
+          wordCount={10}
+        />
+      )
+      expect(screen.getByLabelText(/session summary/i)).toBeInTheDocument()
+    })
+
+    it('should have aria-expanded on the collapse button', () => {
+      render(
+        <SessionSummaryCard
+          summary="Test summary"
+          leafUuid="uuid-123"
+          wordCount={10}
+        />
+      )
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('aria-expanded')
+    })
+
+    it('should have aria-hidden on the icon', () => {
+      const { container } = render(
+        <SessionSummaryCard
+          summary="Test summary"
+          leafUuid="uuid-123"
+          wordCount={10}
+        />
+      )
+      const svg = container.querySelector('svg')
+      expect(svg?.getAttribute('aria-hidden')).toBe('true')
+    })
+  })
+})

--- a/src/components/SessionSummaryCard.tsx
+++ b/src/components/SessionSummaryCard.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import { BookOpen, ChevronRight, ChevronDown } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+interface SessionSummaryCardProps {
+  summary: string
+  leafUuid: string
+  wordCount: number
+}
+
+const TRUNCATE_LENGTH = 150
+
+export function SessionSummaryCard({
+  summary,
+  leafUuid,
+  wordCount,
+}: SessionSummaryCardProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  if (!summary || summary.trim().length === 0) {
+    return (
+      <div
+        className={cn(
+          'rounded-lg border border-gray-200 border-l-4 border-l-rose-300 bg-rose-50 p-3 my-2'
+        )}
+        aria-label="Session summary"
+      >
+        <div className="flex items-start gap-2">
+          <BookOpen
+            className="w-4 h-4 text-rose-500 mt-0.5 flex-shrink-0"
+            aria-hidden="true"
+          />
+          <div className="text-sm text-rose-700">No summary available</div>
+        </div>
+      </div>
+    )
+  }
+
+  const needsTruncation = summary.length > TRUNCATE_LENGTH
+  const displayText = expanded || !needsTruncation
+    ? summary
+    : summary.slice(0, TRUNCATE_LENGTH) + '...'
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-gray-200 border-l-4 border-l-rose-300 overflow-hidden bg-white my-2'
+      )}
+      aria-label="Session summary"
+      data-leaf-uuid={leafUuid}
+    >
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-start gap-2 px-3 py-2 text-left bg-rose-50 hover:bg-rose-100 transition-colors"
+        aria-expanded={expanded}
+      >
+        <BookOpen
+          className="w-4 h-4 text-rose-500 mt-0.5 flex-shrink-0"
+          aria-hidden="true"
+        />
+        <div className="flex-1 min-w-0">
+          <div className="text-sm text-rose-800">
+            <span className="font-medium">Session summary:</span>{' '}
+            {displayText}
+          </div>
+          <div className="text-xs text-rose-500 mt-1">
+            {wordCount} words
+          </div>
+        </div>
+        {needsTruncation && (
+          expanded ? (
+            <ChevronDown className="w-4 h-4 text-rose-400 flex-shrink-0 mt-0.5" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-rose-400 flex-shrink-0 mt-0.5" />
+          )
+        )}
+      </button>
+    </div>
+  )
+}

--- a/src/components/StructuredDataCard.tsx
+++ b/src/components/StructuredDataCard.tsx
@@ -7,39 +7,22 @@ interface StructuredDataCardProps {
 }
 
 /**
- * Safely renders untrusted XML/HTML content using DOMPurify sanitization.
+ * Safely renders untrusted XML/HTML content as plain text.
  *
- * Security features:
- * - Removes all script tags and event handlers
- * - Allows only safe structural tags: div, span, p, br, ul, ol, li, pre, code
- * - Strips all attributes to prevent onclick/onerror injection
- * - Uses zero-copy KEEP_CONTENT mode to preserve text content
- *
- * Performance:
- * - Uses memmem-style SIMD filtering in DOMPurify's internal implementation
- * - Handles 1MB+ XML efficiently (sanitization < 1s on modern hardware)
- *
- * Why dangerouslySetInnerHTML is safe here:
- * - Content is always sanitized by DOMPurify before rendering
- * - ALLOWED_TAGS whitelist prevents script injection
- * - ALLOWED_ATTR: [] prevents event handler attributes
- * - KEEP_CONTENT ensures no data loss while stripping unsafe content
+ * Security: Strips ALL tags and attributes via DOMPurify, then renders
+ * the text content through React (auto-escaped). No dangerouslySetInnerHTML.
  */
 export function StructuredDataCard({
   xml,
 }: StructuredDataCardProps) {
-  // Sanitize XML with DOMPurify (hook must be called unconditionally)
-  // Wrapped in useMemo to prevent re-sanitization on every render
-  // ALLOWED_TAGS: Only safe structural tags, no script/iframe/style
-  // ALLOWED_ATTR: Empty array = no attributes = no onclick/onerror/src injection
-  // KEEP_CONTENT: Preserve text content when stripping unsafe tags
-  const sanitizedXml = useMemo(
+  // Strip all HTML/XML tags, keep only text content
+  const plainText = useMemo(
     () => {
       if (!xml || !xml.trim()) {
         return ''
       }
       return DOMPurify.sanitize(xml, {
-        ALLOWED_TAGS: ['div', 'span', 'p', 'br', 'ul', 'ol', 'li', 'pre', 'code'],
+        ALLOWED_TAGS: [],
         ALLOWED_ATTR: [],
         KEEP_CONTENT: true,
       })
@@ -48,7 +31,7 @@ export function StructuredDataCard({
   )
 
   // Handle empty/null/undefined content
-  if (!sanitizedXml.trim()) {
+  if (!plainText.trim()) {
     return <div className="text-gray-500">No data</div>
   }
 
@@ -59,9 +42,9 @@ export function StructuredDataCard({
           className="whitespace-pre-wrap break-words text-xs bg-gray-50 p-2 rounded border border-gray-100"
           role="document"
           aria-label="Structured data content"
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: sanitizedXml }}
-        />
+        >
+          {plainText}
+        </pre>
       </div>
     </div>
   )

--- a/src/components/TaskQueueCard.test.tsx
+++ b/src/components/TaskQueueCard.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TaskQueueCard } from './TaskQueueCard'
+
+describe('TaskQueueCard', () => {
+  describe('Title and status rendering', () => {
+    it('should display waiting info with position and duration', () => {
+      render(
+        <TaskQueueCard waitDuration={1.2} position={3} queueLength={8} />
+      )
+
+      expect(screen.getByText(/Waiting for task/)).toBeInTheDocument()
+      expect(screen.getByText(/position 3\/8/)).toBeInTheDocument()
+      expect(screen.getByText(/1\.2s/)).toBeInTheDocument()
+    })
+
+    it('should show just "Waiting for task..." when all props undefined', () => {
+      render(<TaskQueueCard />)
+
+      expect(screen.getByText(/Waiting for task\.\.\./)).toBeInTheDocument()
+    })
+
+    it('should have gray left border', () => {
+      const { container } = render(<TaskQueueCard />)
+
+      const card = container.firstElementChild as HTMLElement
+      expect(card.className).toContain('border-l-gray')
+    })
+  })
+
+  describe('No collapse', () => {
+    it('should not have a button (not collapsible)', () => {
+      render(<TaskQueueCard position={1} queueLength={5} />)
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('ARIA', () => {
+    it('should have ARIA label on the card', () => {
+      render(<TaskQueueCard />)
+
+      expect(screen.getByLabelText(/task queue/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should show position without queue length', () => {
+      render(<TaskQueueCard position={2} />)
+
+      expect(screen.getByText(/position 2/)).toBeInTheDocument()
+    })
+
+    it('should show duration without position', () => {
+      render(<TaskQueueCard waitDuration={3.5} />)
+
+      expect(screen.getByText(/3\.5s/)).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/TaskQueueCard.tsx
+++ b/src/components/TaskQueueCard.tsx
@@ -1,0 +1,47 @@
+import { Clock } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+interface TaskQueueCardProps {
+  waitDuration?: number
+  position?: number
+  queueLength?: number
+}
+
+export function TaskQueueCard({
+  waitDuration,
+  position,
+  queueLength,
+}: TaskQueueCardProps) {
+  const details: string[] = []
+
+  if (position !== undefined) {
+    details.push(
+      queueLength !== undefined
+        ? `position ${position}/${queueLength}`
+        : `position ${position}`
+    )
+  }
+
+  if (waitDuration !== undefined) {
+    details.push(`${waitDuration}s`)
+  }
+
+  const hasDetails = details.length > 0
+  const suffix = hasDetails ? ` (${details.join(', ')})` : '...'
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-gray-200 border-l-4 border-l-gray-400 bg-gray-50 my-2 overflow-hidden'
+      )}
+      aria-label="Task queue status"
+    >
+      <div className="flex items-center gap-2 px-3 py-2">
+        <Clock className="w-4 h-4 text-gray-500 flex-shrink-0" aria-hidden="true" />
+        <span className="text-sm text-gray-700">
+          Waiting for task{suffix}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ToolCallCard.test.tsx
+++ b/src/components/ToolCallCard.test.tsx
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ToolCallCard } from './ToolCallCard'
+
+describe('ToolCallCard', () => {
+  describe('Rendering basics', () => {
+    it('renders tool name', () => {
+      render(<ToolCallCard name="Read" input={{ file_path: '/src/index.ts' }} description="Read a file" />)
+      expect(screen.getByText('Read')).toBeInTheDocument()
+    })
+
+    it('renders different tool names (Edit, Bash, etc.)', () => {
+      const { rerender } = render(
+        <ToolCallCard name="Edit" input={{ file_path: '/src/app.ts' }} description="Edit a file" />
+      )
+      expect(screen.getByText('Edit')).toBeInTheDocument()
+
+      rerender(
+        <ToolCallCard name="Bash" input={{ command: 'ls -la' }} description="Run a command" />
+      )
+      expect(screen.getByText('Bash')).toBeInTheDocument()
+    })
+
+    it('renders input parameters (file_path)', () => {
+      render(
+        <ToolCallCard
+          name="Read"
+          input={{ file_path: '/Users/dev/project/src/index.ts' }}
+          description="Read source file"
+        />
+      )
+      expect(screen.getByText(/\/Users\/dev\/project\/src\/index.ts/)).toBeInTheDocument()
+    })
+
+    it('renders input parameters (command)', () => {
+      render(
+        <ToolCallCard
+          name="Bash"
+          input={{ command: 'npm install' }}
+          description="Install dependencies"
+        />
+      )
+      expect(screen.getByText(/npm install/)).toBeInTheDocument()
+    })
+
+    it('renders input parameters (pattern)', () => {
+      render(
+        <ToolCallCard
+          name="Grep"
+          input={{ pattern: 'TODO_FIXME', path: '/src' }}
+          description="Search for items"
+        />
+      )
+      expect(screen.getByText(/TODO_FIXME/)).toBeInTheDocument()
+    })
+
+    it('shows description of what was attempted', () => {
+      render(
+        <ToolCallCard name="Read" input={{ file_path: '/foo.ts' }} description="Read the config file" />
+      )
+      expect(screen.getByText('Read the config file')).toBeInTheDocument()
+    })
+  })
+
+  describe('Collapse/Expand behavior', () => {
+    it('collapses by default (summary visible, details hidden)', () => {
+      render(
+        <ToolCallCard
+          name="Read"
+          input={{ file_path: '/src/index.ts' }}
+          description="Read source file"
+          parameters={{ file_path: '/src/index.ts', limit: 100 }}
+        />
+      )
+      expect(screen.getByText('Read')).toBeInTheDocument()
+      const button = screen.getByRole('button', { name: /tool call/i })
+      expect(button).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('expands to show full details on click', () => {
+      render(
+        <ToolCallCard
+          name="Read"
+          input={{ file_path: '/src/index.ts' }}
+          description="Read source file"
+          parameters={{ file_path: '/src/index.ts', limit: 100 }}
+        />
+      )
+      const button = screen.getByRole('button', { name: /tool call/i })
+      expect(button).toHaveAttribute('aria-expanded', 'false')
+
+      fireEvent.click(button)
+
+      expect(button).toHaveAttribute('aria-expanded', 'true')
+      expect(screen.getByText(/limit/)).toBeInTheDocument()
+    })
+
+    it('collapses again on second click', () => {
+      render(
+        <ToolCallCard
+          name="Edit"
+          input={{ file_path: '/src/app.ts' }}
+          description="Edit file"
+          parameters={{ file_path: '/src/app.ts', old_string: 'foo', new_string: 'bar' }}
+        />
+      )
+      const button = screen.getByRole('button', { name: /tool call/i })
+
+      fireEvent.click(button) // expand
+      expect(button).toHaveAttribute('aria-expanded', 'true')
+
+      fireEvent.click(button) // collapse
+      expect(button).toHaveAttribute('aria-expanded', 'false')
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('handles missing parameters gracefully (no crash)', () => {
+      render(
+        <ToolCallCard name="Read" input={{ file_path: '/foo.ts' }} description="Read file" />
+      )
+      expect(screen.getByText('Read')).toBeInTheDocument()
+    })
+
+    it('renders "No parameters" when parameters is undefined and expanded', () => {
+      render(
+        <ToolCallCard name="Read" input={{ file_path: '/foo.ts' }} description="Read file" />
+      )
+      const button = screen.getByRole('button', { name: /tool call/i })
+      fireEvent.click(button)
+      expect(screen.getByText('No parameters')).toBeInTheDocument()
+    })
+
+    it('renders gracefully when name is empty string', () => {
+      const { container } = render(
+        <ToolCallCard name="" input={{}} description="Unknown tool" />
+      )
+      expect(container).toBeInTheDocument()
+      expect(screen.getByText('Unknown tool')).toBeInTheDocument()
+    })
+
+    it('wraps description >500 chars without truncation', () => {
+      const longDescription = 'B'.repeat(600)
+      render(
+        <ToolCallCard name="Read" input={{ file_path: '/foo.ts' }} description={longDescription} />
+      )
+      const button = screen.getByRole('button', { name: /tool call/i })
+      fireEvent.click(button)
+      // Description appears in both header subtitle and expanded area
+      const matches = screen.getAllByText(longDescription)
+      expect(matches.length).toBeGreaterThanOrEqual(1)
+      // Verify the expanded area contains the full description with break-words
+      const expandedDesc = matches.find(el => el.classList.contains('break-words'))
+      expect(expandedDesc).toBeTruthy()
+    })
+
+    it('handles special chars in path (spaces, unicode)', () => {
+      render(
+        <ToolCallCard
+          name="Read"
+          input={{ file_path: '/Users/dev/my project/src/日本語.ts' }}
+          description="Read unicode file"
+        />
+      )
+      expect(screen.getByText(/\/Users\/dev\/my project\/src\/日本語.ts/)).toBeInTheDocument()
+    })
+
+    it('truncates very long file paths in summary', () => {
+      const longPath = '/Users/dev/' + 'very-long-directory-name/'.repeat(10) + 'file.ts'
+      render(
+        <ToolCallCard
+          name="Read"
+          input={{ file_path: longPath }}
+          description="Read file"
+        />
+      )
+      // The summary should show a truncated path (the filename at least)
+      expect(screen.getByText(/file\.ts/)).toBeInTheDocument()
+      // The container should not cause horizontal scroll (checked via CSS class)
+      const summary = screen.getByText(/file\.ts/)
+      expect(summary.closest('[class*="truncate"]') || summary.closest('[class*="break"]')).toBeTruthy()
+    })
+  })
+
+  describe('Icon', () => {
+    it('shows icon with aria-hidden="true"', () => {
+      const { container } = render(
+        <ToolCallCard name="Read" input={{ file_path: '/foo.ts' }} description="Read file" />
+      )
+      const icon = container.querySelector('svg[aria-hidden="true"]')
+      expect(icon).toBeInTheDocument()
+    })
+
+    it('renders custom icon when provided', () => {
+      const CustomIcon = () => <span data-testid="custom-icon">Custom</span>
+      render(
+        <ToolCallCard
+          name="Read"
+          input={{ file_path: '/foo.ts' }}
+          description="Read file"
+          icon={<CustomIcon />}
+        />
+      )
+      expect(screen.getByTestId('custom-icon')).toBeInTheDocument()
+    })
+  })
+
+  describe('Copy button', () => {
+    const mockWriteText = vi.fn().mockResolvedValue(undefined)
+
+    beforeEach(() => {
+      mockWriteText.mockClear()
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: mockWriteText },
+        writable: true,
+        configurable: true,
+      })
+    })
+
+    it('has a copy button that copies input to clipboard', () => {
+      render(
+        <ToolCallCard
+          name="Bash"
+          input={{ command: 'npm install' }}
+          description="Install deps"
+        />
+      )
+      // Expand to see copy button
+      const expandButton = screen.getByRole('button', { name: /tool call/i })
+      fireEvent.click(expandButton)
+
+      const copyButton = screen.getByRole('button', { name: /copy/i })
+      expect(copyButton).toBeInTheDocument()
+
+      fireEvent.click(copyButton)
+      expect(mockWriteText).toHaveBeenCalledWith(
+        JSON.stringify({ command: 'npm install' }, null, 2)
+      )
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('button is keyboard-focusable', () => {
+      render(
+        <ToolCallCard name="Read" input={{ file_path: '/foo.ts' }} description="Read file" />
+      )
+      const button = screen.getByRole('button', { name: /tool call/i })
+      button.focus()
+      expect(button).toHaveFocus()
+    })
+
+    it('Enter key triggers click on button (native behavior)', () => {
+      render(
+        <ToolCallCard
+          name="Read"
+          input={{ file_path: '/foo.ts' }}
+          description="Read file"
+          parameters={{ file_path: '/foo.ts' }}
+        />
+      )
+      const button = screen.getByRole('button', { name: /tool call/i })
+      expect(button).toHaveAttribute('aria-expanded', 'false')
+
+      // Simulate Enter key which fires click on buttons natively
+      fireEvent.click(button)
+      expect(button).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('screen reader announces "Tool Call" + name', () => {
+      render(
+        <ToolCallCard name="Read" input={{ file_path: '/foo.ts' }} description="Read file" />
+      )
+      const button = screen.getByRole('button', { name: /tool call.*read/i })
+      expect(button).toBeInTheDocument()
+    })
+
+    it('expand button has aria-expanded attribute', () => {
+      render(
+        <ToolCallCard name="Read" input={{ file_path: '/foo.ts' }} description="Read file" />
+      )
+      const button = screen.getByRole('button', { name: /tool call/i })
+      expect(button).toHaveAttribute('aria-expanded')
+    })
+
+    it('focus ring visible on button (has focus-visible class)', () => {
+      render(
+        <ToolCallCard name="Read" input={{ file_path: '/foo.ts' }} description="Read file" />
+      )
+      const button = screen.getByRole('button', { name: /tool call/i })
+      expect(button.className).toMatch(/focus/)
+    })
+  })
+})

--- a/src/components/ToolCallCard.tsx
+++ b/src/components/ToolCallCard.tsx
@@ -1,0 +1,150 @@
+import { useState } from 'react'
+import { Wrench, ChevronRight, ChevronDown, Copy, Check } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+interface ToolCallCardProps {
+  name: string
+  input: Record<string, unknown>
+  description: string
+  parameters?: Record<string, unknown>
+  icon?: React.ReactNode
+}
+
+/**
+ * Extracts a summary string from tool input for display in the collapsed header.
+ * Prioritizes file_path, command, and pattern fields.
+ */
+function getInputSummary(input: Record<string, unknown>): string {
+  if (input.file_path && typeof input.file_path === 'string') {
+    return input.file_path
+  }
+  if (input.command && typeof input.command === 'string') {
+    return input.command
+  }
+  if (input.pattern && typeof input.pattern === 'string') {
+    return input.pattern
+  }
+  // Fallback: show first string value
+  for (const value of Object.values(input)) {
+    if (typeof value === 'string') return value
+  }
+  return ''
+}
+
+export function ToolCallCard({
+  name,
+  input,
+  description,
+  parameters,
+  icon,
+}: ToolCallCardProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const inputSummary = getInputSummary(input)
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(input, null, 2))
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard API unavailable (non-HTTPS or older browser)
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-purple-200 border-l-4 border-l-purple-300 overflow-hidden bg-white my-2">
+      {/* Header - always visible */}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        aria-label={`Tool Call ${name}`}
+        className={cn(
+          'w-full flex flex-col gap-1 px-3 py-2 text-left',
+          'hover:bg-purple-50 transition-colors',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-1'
+        )}
+      >
+        <div className="flex items-center gap-2 w-full">
+          {/* Icon */}
+          {icon ? (
+            <span className="flex-shrink-0">{icon}</span>
+          ) : (
+            <Wrench className="w-4 h-4 text-purple-500 flex-shrink-0" aria-hidden="true" />
+          )}
+
+          {/* Tool name */}
+          {name && (
+            <span className="text-sm font-semibold text-purple-700 flex-shrink-0">
+              {name}
+            </span>
+          )}
+
+          {/* Input summary - truncated */}
+          {inputSummary && (
+            <>
+              <span className="text-purple-300 flex-shrink-0">&middot;</span>
+              <span className="text-sm text-purple-600 truncate flex-1 font-mono">
+                {inputSummary}
+              </span>
+            </>
+          )}
+
+          {/* Chevron */}
+          {expanded ? (
+            <ChevronDown className="w-4 h-4 text-purple-400 flex-shrink-0" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-purple-400 flex-shrink-0" />
+          )}
+        </div>
+
+        {/* Description - always visible as subtitle */}
+        {description && (
+          <span className="text-xs text-purple-600 break-words pl-6">
+            {description}
+          </span>
+        )}
+      </button>
+
+      {/* Expanded details */}
+      {expanded && (
+        <div className="px-3 py-2 border-t border-purple-100 bg-purple-50">
+          {/* Description */}
+          <p className="text-sm text-purple-800 break-words">{description}</p>
+
+          {/* Parameters */}
+          <div className="mt-2">
+            {parameters ? (
+              <pre className="text-xs text-purple-700 font-mono whitespace-pre-wrap break-all bg-purple-100 rounded p-2">
+                {JSON.stringify(parameters, null, 2)}
+              </pre>
+            ) : (
+              <p className="text-xs text-purple-500 italic">No parameters</p>
+            )}
+          </div>
+
+          {/* Copy button */}
+          <div className="mt-2 flex justify-end">
+            <button
+              onClick={handleCopy}
+              aria-label={copied ? 'Copied' : 'Copy input'}
+              className={cn(
+                'flex items-center gap-1 px-2 py-1 text-xs rounded',
+                'text-purple-600 hover:bg-purple-200 transition-colors',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400'
+              )}
+            >
+              {copied ? (
+                <Check className="w-3 h-3" aria-hidden="true" />
+              ) : (
+                <Copy className="w-3 h-3" aria-hidden="true" />
+              )}
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/TurnDurationCard.test.tsx
+++ b/src/components/TurnDurationCard.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TurnDurationCard } from './TurnDurationCard'
+
+describe('TurnDurationCard', () => {
+  describe('Happy path', () => {
+    it('should render duration in milliseconds', () => {
+      render(<TurnDurationCard durationMs={245} />)
+      expect(screen.getByText(/245ms/)).toBeInTheDocument()
+    })
+
+    it('should display "Turn completed in" message', () => {
+      render(<TurnDurationCard durationMs={500} />)
+      expect(screen.getByText(/Turn completed in 500ms/)).toBeInTheDocument()
+    })
+
+    it('should render start and end times when provided', () => {
+      render(
+        <TurnDurationCard
+          durationMs={1200}
+          startTime="10:30:00"
+          endTime="10:30:01"
+        />
+      )
+      expect(screen.getByText(/10:30:00/)).toBeInTheDocument()
+      expect(screen.getByText(/10:30:01/)).toBeInTheDocument()
+    })
+
+    it('should render the clock icon', () => {
+      const { container } = render(<TurnDurationCard durationMs={100} />)
+      const svg = container.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+
+    it('should have amber styling', () => {
+      const { container } = render(<TurnDurationCard durationMs={100} />)
+      const wrapper = container.firstElementChild as HTMLElement
+      expect(wrapper.className).toMatch(/amber/)
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should show "0ms" when durationMs is 0', () => {
+      render(<TurnDurationCard durationMs={0} />)
+      expect(screen.getByText(/0ms/)).toBeInTheDocument()
+    })
+
+    it('should render without start/end times', () => {
+      const { container } = render(<TurnDurationCard durationMs={300} />)
+      expect(container).toBeInTheDocument()
+      expect(screen.getByText(/300ms/)).toBeInTheDocument()
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have aria-hidden on decorative icon', () => {
+      const { container } = render(<TurnDurationCard durationMs={100} />)
+      const svg = container.querySelector('svg')
+      expect(svg?.getAttribute('aria-hidden')).toBe('true')
+    })
+
+    it('should have a role for the timing badge', () => {
+      render(<TurnDurationCard durationMs={245} />)
+      expect(screen.getByRole('status')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/TurnDurationCard.tsx
+++ b/src/components/TurnDurationCard.tsx
@@ -1,0 +1,30 @@
+import { Clock } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+interface TurnDurationCardProps {
+  durationMs?: number
+  startTime?: string
+  endTime?: string
+}
+
+export function TurnDurationCard({ durationMs, startTime, endTime }: TurnDurationCardProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 my-2 px-3 py-2 rounded-lg',
+        'border border-amber-300 bg-amber-50'
+      )}
+      role="status"
+    >
+      <Clock className="w-4 h-4 text-amber-600 flex-shrink-0" aria-hidden="true" />
+      <span className="text-sm font-medium text-amber-800">
+        Turn completed in {durationMs !== undefined ? `${durationMs}ms` : 'unknown duration'}
+      </span>
+      {startTime && endTime && (
+        <span className="text-xs text-amber-600 ml-auto">
+          {startTime} — {endTime}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/components/XmlCard.test.tsx
+++ b/src/components/XmlCard.test.tsx
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { XmlCard, detectXmlType, extractXmlBlocks } from './XmlCard'
+
+// Mock ToolCallCard to verify it gets rendered with correct props
+vi.mock('./ToolCallCard', () => ({
+  ToolCallCard: ({ name, input, description }: { name: string; input: Record<string, unknown>; description: string }) => (
+    <div data-testid="tool-call-card" data-name={name} data-description={description}>
+      ToolCallCard: {name} - {description} - {JSON.stringify(input)}
+    </div>
+  ),
+}))
+
+// Mock StructuredDataCard to verify it gets rendered with correct props
+vi.mock('./StructuredDataCard', () => ({
+  StructuredDataCard: ({ xml, type }: { xml: string; type?: string }) => (
+    <div data-testid="structured-data-card" data-type={type}>
+      StructuredDataCard: {xml}
+    </div>
+  ),
+}))
+
+describe('XmlCard', () => {
+  describe('tool_call type renders ToolCallCard', () => {
+    it('renders ToolCallCard instead of CodeBlock for tool_call type', () => {
+      const xml = `<tool_call>
+        <tool_name>Read</tool_name>
+        <parameters>{"file_path": "/src/index.ts"}</parameters>
+        <what_happened>Read a file</what_happened>
+      </tool_call>`
+
+      render(<XmlCard content={xml} type="tool_call" />)
+
+      expect(screen.getByTestId('tool-call-card')).toBeInTheDocument()
+      expect(screen.getByTestId('tool-call-card')).toHaveAttribute('data-name', 'Read')
+      expect(screen.getByTestId('tool-call-card')).toHaveAttribute('data-description', 'Read a file')
+    })
+
+    it('extracts JSON input from parameters tag', () => {
+      const xml = `<tool_call>
+        <tool_name>Bash</tool_name>
+        <parameters>{"command": "npm install"}</parameters>
+        <what_happened>Run install</what_happened>
+      </tool_call>`
+
+      render(<XmlCard content={xml} type="tool_call" />)
+
+      const card = screen.getByTestId('tool-call-card')
+      expect(card.textContent).toContain('"command":"npm install"')
+    })
+
+    it('extracts working_directory as input field', () => {
+      const xml = `<tool_call>
+        <tool_name>Bash</tool_name>
+        <parameters>{"command": "ls"}</parameters>
+        <what_happened>List files</what_happened>
+        <working_directory>/Users/dev/project</working_directory>
+      </tool_call>`
+
+      render(<XmlCard content={xml} type="tool_call" />)
+
+      const card = screen.getByTestId('tool-call-card')
+      expect(card.textContent).toContain('/Users/dev/project')
+    })
+
+    it('falls back to "Tool Call" name when no name tag', () => {
+      const xml = `<tool_call>
+        <parameters>{"file_path": "/foo.ts"}</parameters>
+        <what_happened>Did something</what_happened>
+      </tool_call>`
+
+      render(<XmlCard content={xml} type="tool_call" />)
+
+      expect(screen.getByTestId('tool-call-card')).toHaveAttribute('data-name', 'Tool Call')
+    })
+
+    it('handles non-JSON parameters gracefully', () => {
+      const xml = `<tool_call>
+        <tool_name>Read</tool_name>
+        <parameters>some plain text value</parameters>
+        <what_happened>Read something</what_happened>
+      </tool_call>`
+
+      render(<XmlCard content={xml} type="tool_call" />)
+
+      const card = screen.getByTestId('tool-call-card')
+      expect(card.textContent).toContain('some plain text value')
+    })
+
+    it('does not render CodeBlock for tool_call type', () => {
+      const xml = `<tool_call>
+        <tool_name>Read</tool_name>
+        <parameters>{"file_path": "/src/index.ts"}</parameters>
+        <what_happened>Read a file</what_happened>
+      </tool_call>`
+
+      const { container } = render(<XmlCard content={xml} type="tool_call" />)
+
+      // CodeBlock would render a <pre><code> block; ToolCallCard does not
+      expect(container.querySelector('[data-testid="tool-call-card"]')).toBeInTheDocument()
+      // No CodeBlock should be present
+      expect(container.querySelector('code')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('unknown type renders StructuredDataCard', () => {
+    it('renders StructuredDataCard instead of CodeBlock for unknown type', () => {
+      const xml = `<custom_tag>
+        <inner>Some structured data</inner>
+      </custom_tag>`
+
+      render(<XmlCard content={xml} type="unknown" />)
+
+      expect(screen.getByTestId('structured-data-card')).toBeInTheDocument()
+      expect(screen.getByTestId('structured-data-card')).toHaveAttribute('data-type', 'unknown')
+    })
+
+    it('passes full XML content to StructuredDataCard', () => {
+      const xml = `<data><field>value</field></data>`
+
+      render(<XmlCard content={xml} type="unknown" />)
+
+      const card = screen.getByTestId('structured-data-card')
+      expect(card.textContent).toContain('<data><field>value</field></data>')
+    })
+
+    it('does not render CodeBlock for unknown type', () => {
+      const xml = `<some_xml><nested>content</nested></some_xml>`
+
+      const { container } = render(<XmlCard content={xml} type="unknown" />)
+
+      expect(container.querySelector('[data-testid="structured-data-card"]')).toBeInTheDocument()
+      expect(container.querySelector('code')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('existing card types still work', () => {
+    it('renders nothing for hidden type', () => {
+      const { container } = render(<XmlCard content="<system-reminder>hidden</system-reminder>" type="hidden" />)
+      expect(container.innerHTML).toBe('')
+    })
+
+    it('renders local_command as terminal output', () => {
+      const xml = `<local-command-stdout>hello world</local-command-stdout>`
+      render(<XmlCard content={xml} type="local_command" />)
+      expect(screen.getByText('hello world')).toBeInTheDocument()
+    })
+
+    it('renders task_notification as agent status card', () => {
+      const xml = `<task-notification>
+        <status>completed</status>
+        <summary>Task done</summary>
+        <result>Success</result>
+      </task-notification>`
+      render(<XmlCard content={xml} type="task_notification" />)
+      expect(screen.getByText('Task done')).toBeInTheDocument()
+    })
+
+    it('renders tool_error as red error card', () => {
+      const xml = `<tool_use_error>File not found</tool_use_error>`
+      render(<XmlCard content={xml} type="tool_error" />)
+      expect(screen.getByText('Tool Error')).toBeInTheDocument()
+      expect(screen.getAllByText('File not found').length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('renders command as indigo card', () => {
+      const xml = `<command-name>git status</command-name>
+        <command-message>Check status</command-message>
+        <command-args>--short</command-args>`
+      render(<XmlCard content={xml} type="command" />)
+      expect(screen.getByText('git status')).toBeInTheDocument()
+    })
+
+    it('renders observation with parsed facts', () => {
+      const xml = `<observation>
+        <type>Architecture</type>
+        <title>Project structure</title>
+        <facts><fact>Uses React</fact><fact>Uses TypeScript</fact></facts>
+      </observation>`
+      render(<XmlCard content={xml} type="observation" />)
+      expect(screen.getByText(/Architecture · Project structure/)).toBeInTheDocument()
+    })
+
+    it('renders observed_from_primary_session with action summary', () => {
+      const xml = `<observed_from_primary_session>
+        <what_happened>Read file</what_happened>
+        <parameters>/src/index.ts</parameters>
+      </observed_from_primary_session>`
+      render(<XmlCard content={xml} type="observed_from_primary_session" />)
+      expect(screen.getByText(/Read file/)).toBeInTheDocument()
+    })
+  })
+
+  describe('detectXmlType', () => {
+    it('detects tool_call type', () => {
+      expect(detectXmlType('<tool_call><name>Read</name></tool_call>')).toBe('tool_call')
+    })
+
+    it('detects unknown type for generic XML', () => {
+      const xml = '<custom_structure>' + 'a'.repeat(100) + '</custom_structure>'
+      expect(detectXmlType(xml)).toBe('unknown')
+    })
+
+    it('returns null for non-XML content', () => {
+      expect(detectXmlType('just plain text')).toBeNull()
+    })
+  })
+
+  describe('extractXmlBlocks', () => {
+    it('extracts tool_call blocks with correct type', () => {
+      const content = 'Some text <tool_call><name>Read</name></tool_call> more text'
+      const blocks = extractXmlBlocks(content)
+      const toolBlock = blocks.find(b => b.type === 'tool_call')
+      expect(toolBlock).toBeDefined()
+      expect(toolBlock!.xml).toContain('<tool_call>')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add 14 new/enhanced semantic card components replacing raw XML/codeblock dumps with accessible, themed UI cards
- Components cover tool calls, system events, progress events, queue operations, file snapshots, and session summaries
- Update MessageTyped dispatch, StructuredDataCard, and XmlCard routing to integrate new components
- Full test coverage with 35 files changed (3,386 insertions)

## Test plan
- [ ] Run `npx vitest run` to verify all unit tests pass
- [ ] Verify new card components render correctly in browser
- [ ] Check accessibility: keyboard navigation, ARIA labels, screen reader support
- [ ] Confirm collapsible cards expand/collapse properly
- [ ] Validate color themes match design spec per component type

🤖 Generated with [Claude Code](https://claude.com/claude-code)