### PR TITLE
feat(server): add env vars for platform bypass and bind address

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -199,9 +199,13 @@ async fn main() -> Result<()> {
     let startup_start = Instant::now();
 
     // Platform gate: macOS only for now (Linux v2.1, Windows v2.2)
-    if std::env::consts::OS != "macos" {
+    // Set CLAUDE_VIEW_SKIP_PLATFORM_CHECK=1 to bypass (e.g. Docker Linux containers)
+    if std::env::consts::OS != "macos"
+        && std::env::var("CLAUDE_VIEW_SKIP_PLATFORM_CHECK").as_deref() != Ok("1")
+    {
         eprintln!("\n\u{26a0}\u{fe0f}  claude-view currently supports macOS only.");
         eprintln!("   Linux support is planned for v2.1, Windows for v2.2.");
+        eprintln!("   Set CLAUDE_VIEW_SKIP_PLATFORM_CHECK=1 to bypass (e.g. Docker).");
         eprintln!("   Follow progress: https://github.com/tombelieber/claude-view/issues\n");
         std::process::exit(1);
     }
@@ -343,7 +347,11 @@ async fn main() -> Result<()> {
 
     // Step 5: Bind and start the HTTP server IMMEDIATELY (before any indexing)
     let port = get_port();
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let bind_addr: std::net::IpAddr = std::env::var("CLAUDE_VIEW_BIND_ADDR")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+    let addr = SocketAddr::from((bind_addr, port));
     let listener = tokio::net::TcpListener::bind(addr).await?;
 
     // Step 6: Resolve the claude dir for indexing


### PR DESCRIPTION
## Summary

- Add `CLAUDE_VIEW_SKIP_PLATFORM_CHECK=1` env var to bypass the macOS-only platform gate, enabling the server to run on Linux (e.g. Docker containers)
- Add `CLAUDE_VIEW_BIND_ADDR` env var to configure the server bind address (defaults to `127.0.0.1`, set to `0.0.0.0` for container environments)

Both are fully backward-compatible — existing behavior is unchanged without these variables set.

## Motivation

These are prerequisites for running claude-view in Docker on non-macOS hosts (Linux containers, Windows via Docker Desktop). They also benefit any deployment where the server needs to bind to a non-loopback address.

## Changes

- `crates/server/src/main.rs`: Platform gate now checks `CLAUDE_VIEW_SKIP_PLATFORM_CHECK` before exiting
- `crates/server/src/main.rs`: Bind address is parsed from `CLAUDE_VIEW_BIND_ADDR` with localhost fallback

## Test plan

- [ ] Verify server starts normally on macOS without env vars set (no behavior change)
- [ ] Verify `CLAUDE_VIEW_SKIP_PLATFORM_CHECK=1` allows startup on Linux
- [ ] Verify `CLAUDE_VIEW_BIND_ADDR=0.0.0.0` binds to all interfaces
- [ ] Verify invalid `CLAUDE_VIEW_BIND_ADDR` values fall back to localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)