### PR TITLE
feat(db): session_stats + session_flags migrations + get_stats_header (CQRS Phase 2 PR 2.1)

### DIFF
--- a/crates/db/src/migrations/features.rs
+++ b/crates/db/src/migrations/features.rs
@@ -149,4 +149,111 @@ ALTER TABLE sessions DROP COLUMN correction_count;
 ALTER TABLE sessions DROP COLUMN same_file_edit_count;
 ALTER TABLE models DROP COLUMN sdk_supported;
 COMMIT;"#,
+    // Migration 64: session_stats — Layer-2 typed read-side mirror of the
+    // existing `sessions` row, populated by the Phase 2 indexer_v2 writer
+    // (PR 2.2). STRICT mode enforces declared types; no FK to `sessions`
+    // because shadow mode tolerates transient inconsistency. Schema mirrors
+    // `claude_view_session_parser::SessionStats` — any new SessionStats
+    // field requires a matching ALTER in a future migration (writer
+    // ownership registry, design §10.2).
+    //
+    // Field grouping (32 columns total = 8 staleness/header + 24 stats —
+    // design §3.1 said "9 header + 25 stats = 34" but miscounted):
+    //   header (8)   : session_id PK + content_hash/size/inode/mid_hash
+    //                  staleness + parser/stats versions + indexed_at
+    //   tokens (6)   : input/output/cache_read/cache_creation + 5m/1hr breakdown
+    //   counts (6)   : turns/prompts/lines/tools/thinking/api_errors
+    //   tools  (4)   : files_read/files_edited/bash/agent_spawn
+    //   times  (3)   : first/last message + duration_seconds (unix seconds)
+    //   strings(4)   : primary_model + git_branch + preview + last_message
+    //   per-model(1) : per_model_tokens_json (JSON, normalized at write)
+    //
+    // Indexes target Phase 3 read-cutover queries:
+    //   last_ts + indexed_at: list ordering / "what's new"
+    //   total_tokens (expr) : sort by token cost — uses an expression index
+    //                         on (input + output) since there is no stored
+    //                         total_tokens column. Design §3.1 referenced
+    //                         a non-existent `total_tokens` column; the
+    //                         sum-expression is the minimum-surprise
+    //                         substitute that delivers the same ORDER BY.
+    //   primary_model       : "tokens by model" filter
+    //   git_branch          : per-branch grouping
+    r#"BEGIN;
+CREATE TABLE session_stats (
+    session_id          TEXT PRIMARY KEY,
+    source_content_hash BLOB NOT NULL,
+    source_size         INTEGER NOT NULL,
+    source_inode        INTEGER,
+    source_mid_hash     BLOB,
+    parser_version      INTEGER NOT NULL,
+    stats_version       INTEGER NOT NULL,
+    indexed_at          INTEGER NOT NULL,
+
+    -- Token counts (mirror SessionStats token fields).
+    total_input_tokens          INTEGER NOT NULL DEFAULT 0,
+    total_output_tokens         INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens           INTEGER NOT NULL DEFAULT 0,
+    cache_creation_tokens       INTEGER NOT NULL DEFAULT 0,
+    cache_creation_5m_tokens    INTEGER NOT NULL DEFAULT 0,
+    cache_creation_1hr_tokens   INTEGER NOT NULL DEFAULT 0,
+
+    -- Counts (mirror SessionStats turn / prompt / line / tool / thinking / error).
+    turn_count                  INTEGER NOT NULL DEFAULT 0,
+    user_prompt_count           INTEGER NOT NULL DEFAULT 0,
+    line_count                  INTEGER NOT NULL DEFAULT 0,
+    tool_call_count             INTEGER NOT NULL DEFAULT 0,
+    thinking_block_count        INTEGER NOT NULL DEFAULT 0,
+    api_error_count             INTEGER NOT NULL DEFAULT 0,
+
+    -- Tool breakdown.
+    files_read_count            INTEGER NOT NULL DEFAULT 0,
+    files_edited_count          INTEGER NOT NULL DEFAULT 0,
+    bash_count                  INTEGER NOT NULL DEFAULT 0,
+    agent_spawn_count           INTEGER NOT NULL DEFAULT 0,
+
+    -- Timestamps (unix seconds; RFC3339 string normalized at write time).
+    first_message_at            INTEGER,
+    last_message_at             INTEGER,
+    duration_seconds            INTEGER NOT NULL DEFAULT 0,
+
+    -- Model + git + display strings.
+    primary_model               TEXT,
+    git_branch                  TEXT,
+    preview                     TEXT NOT NULL DEFAULT '',
+    last_message                TEXT NOT NULL DEFAULT '',
+
+    -- Per-model token breakdown (JSON object {model_id: {input, output, ...}}).
+    per_model_tokens_json       TEXT NOT NULL DEFAULT '{}'
+) STRICT;
+CREATE INDEX idx_session_stats_last_ts ON session_stats(last_message_at DESC);
+CREATE INDEX idx_session_stats_indexed_at ON session_stats(indexed_at DESC);
+CREATE INDEX idx_session_stats_total_tokens ON session_stats((total_input_tokens + total_output_tokens) DESC);
+CREATE INDEX idx_session_stats_primary_model ON session_stats(primary_model);
+CREATE INDEX idx_session_stats_git_branch ON session_stats(git_branch);
+COMMIT;"#,
+    // Migration 65: session_flags — append-only fold target for
+    // archive/dismiss/classify mutations. Phase 5 will add the fold writer;
+    // Phase 2 lands the table now so shadow-mode rollups have a stable join
+    // target. All rows start with applied_seq=0; the Phase 5 writer
+    // increments applied_seq INSIDE the fold transaction.
+    //
+    // Indexes target Phase 5 + Phase 6 reads:
+    //   archived: WHERE archived_at IS NOT NULL — partial keeps it sparse.
+    //   category: WHERE category_l1 IS NOT NULL — same sparsity argument.
+    r#"BEGIN;
+CREATE TABLE session_flags (
+    session_id            TEXT PRIMARY KEY,
+    archived_at           INTEGER,
+    dismissed_at          INTEGER,
+    category_l1           TEXT,
+    category_l2           TEXT,
+    category_l3           TEXT,
+    category_confidence   REAL,
+    category_source       TEXT,
+    classified_at         INTEGER,
+    applied_seq           INTEGER NOT NULL DEFAULT 0
+) STRICT;
+CREATE INDEX idx_session_flags_archived ON session_flags(archived_at) WHERE archived_at IS NOT NULL;
+CREATE INDEX idx_session_flags_category ON session_flags(category_l1) WHERE category_l1 IS NOT NULL;
+COMMIT;"#,
 ];

--- a/crates/db/src/migrations/tests.rs
+++ b/crates/db/src/migrations/tests.rs
@@ -1893,3 +1893,253 @@ async fn test_migration63_sdk_supported_dropped() {
         "Migration 63 should have dropped models.sdk_supported"
     );
 }
+
+// ========================================================================
+// Migration 64: session_stats — Phase 2 read-side mirror table
+// ========================================================================
+
+#[tokio::test]
+async fn test_migration64_session_stats_columns_exist() {
+    let pool = setup_db().await;
+    let cols: Vec<(String,)> =
+        sqlx::query_as("SELECT name FROM pragma_table_info('session_stats')")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    let names: Vec<&str> = cols.iter().map(|(n,)| n.as_str()).collect();
+
+    // 9 staleness/header
+    for col in [
+        "session_id",
+        "source_content_hash",
+        "source_size",
+        "source_inode",
+        "source_mid_hash",
+        "parser_version",
+        "stats_version",
+        "indexed_at",
+    ] {
+        assert!(names.contains(&col), "missing session_stats.{}", col);
+    }
+
+    // 6 token columns
+    for col in [
+        "total_input_tokens",
+        "total_output_tokens",
+        "cache_read_tokens",
+        "cache_creation_tokens",
+        "cache_creation_5m_tokens",
+        "cache_creation_1hr_tokens",
+    ] {
+        assert!(names.contains(&col), "missing session_stats.{}", col);
+    }
+
+    // 6 count columns
+    for col in [
+        "turn_count",
+        "user_prompt_count",
+        "line_count",
+        "tool_call_count",
+        "thinking_block_count",
+        "api_error_count",
+    ] {
+        assert!(names.contains(&col), "missing session_stats.{}", col);
+    }
+
+    // 4 tool counts
+    for col in [
+        "files_read_count",
+        "files_edited_count",
+        "bash_count",
+        "agent_spawn_count",
+    ] {
+        assert!(names.contains(&col), "missing session_stats.{}", col);
+    }
+
+    // 3 time columns
+    for col in ["first_message_at", "last_message_at", "duration_seconds"] {
+        assert!(names.contains(&col), "missing session_stats.{}", col);
+    }
+
+    // 4 string columns
+    for col in ["primary_model", "git_branch", "preview", "last_message"] {
+        assert!(names.contains(&col), "missing session_stats.{}", col);
+    }
+
+    // 1 JSON column
+    assert!(
+        names.contains(&"per_model_tokens_json"),
+        "missing session_stats.per_model_tokens_json"
+    );
+
+    // Total = 8 header + 24 stats = 32. The design doc (§3.1) said
+    // "9 header + 25 stats = 34" but miscounted; our schema and this
+    // assertion reflect what actually exists. If this drifts, the writer
+    // ownership registry rule (§10.2) likely needs an update.
+    assert_eq!(
+        names.len(),
+        32,
+        "session_stats column count drifted from the 32 documented in features.rs (got {})",
+        names.len()
+    );
+}
+
+#[tokio::test]
+async fn test_migration64_session_stats_strict_mode_rejects_text_in_int() {
+    // STRICT mode is the headline change vs the legacy `sessions` table —
+    // catches `"123"` (TEXT) being stored where INTEGER is declared.
+    let pool = setup_db().await;
+    let result = sqlx::query(
+        r#"INSERT INTO session_stats (session_id, source_content_hash, source_size,
+                                       parser_version, stats_version, indexed_at,
+                                       total_input_tokens)
+           VALUES ('strict-test', X'00', 1, 1, 1, 0, 'not-an-int')"#,
+    )
+    .execute(&pool)
+    .await;
+    assert!(
+        result.is_err(),
+        "STRICT mode must reject TEXT into total_input_tokens (INTEGER)"
+    );
+}
+
+#[tokio::test]
+async fn test_migration64_session_stats_indexes_created() {
+    let pool = setup_db().await;
+    let indexes: Vec<(String,)> = sqlx::query_as(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='session_stats'",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let index_names: Vec<&str> = indexes.iter().map(|(n,)| n.as_str()).collect();
+
+    for ix in [
+        "idx_session_stats_last_ts",
+        "idx_session_stats_indexed_at",
+        "idx_session_stats_total_tokens",
+        "idx_session_stats_primary_model",
+        "idx_session_stats_git_branch",
+    ] {
+        assert!(index_names.contains(&ix), "missing index {}", ix);
+    }
+}
+
+#[tokio::test]
+async fn test_migration64_session_stats_default_row_inserts() {
+    // All-defaults insert with the 8 NOT NULL no-default columns supplied —
+    // the rest fall back to the migration's DEFAULT 0 / DEFAULT '' clauses.
+    let pool = setup_db().await;
+    sqlx::query(
+        r#"INSERT INTO session_stats (session_id, source_content_hash, source_size,
+                                       parser_version, stats_version, indexed_at)
+           VALUES ('default-row', X'00', 1, 1, 1, 0)"#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let row: (i64, i64, i64, String, String) = sqlx::query_as(
+        r#"SELECT total_input_tokens, turn_count, files_read_count,
+                  preview, per_model_tokens_json
+             FROM session_stats WHERE session_id = 'default-row'"#,
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.0, 0);
+    assert_eq!(row.1, 0);
+    assert_eq!(row.2, 0);
+    assert_eq!(row.3, "");
+    assert_eq!(row.4, "{}");
+}
+
+// ========================================================================
+// Migration 65: session_flags — Phase 5 fold target (table only in Phase 2)
+// ========================================================================
+
+#[tokio::test]
+async fn test_migration65_session_flags_columns_exist() {
+    let pool = setup_db().await;
+    let cols: Vec<(String,)> =
+        sqlx::query_as("SELECT name FROM pragma_table_info('session_flags')")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    let names: Vec<&str> = cols.iter().map(|(n,)| n.as_str()).collect();
+
+    for col in [
+        "session_id",
+        "archived_at",
+        "dismissed_at",
+        "category_l1",
+        "category_l2",
+        "category_l3",
+        "category_confidence",
+        "category_source",
+        "classified_at",
+        "applied_seq",
+    ] {
+        assert!(names.contains(&col), "missing session_flags.{}", col);
+    }
+    assert_eq!(names.len(), 10, "session_flags column count drifted");
+}
+
+#[tokio::test]
+async fn test_migration65_session_flags_partial_indexes_created() {
+    // Both indexes are partial (WHERE x IS NOT NULL) — verify they exist
+    // AND have the partial filter so they stay sparse on the prod DB.
+    let pool = setup_db().await;
+    let indexes: Vec<(String, Option<String>)> = sqlx::query_as(
+        "SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name='session_flags'",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    let by_name: std::collections::HashMap<&str, &Option<String>> =
+        indexes.iter().map(|(n, s)| (n.as_str(), s)).collect();
+
+    let archived = by_name
+        .get("idx_session_flags_archived")
+        .expect("missing idx_session_flags_archived");
+    assert!(
+        archived
+            .as_ref()
+            .map(|s| s.contains("WHERE archived_at IS NOT NULL"))
+            .unwrap_or(false),
+        "archived index lost its WHERE clause: {:?}",
+        archived
+    );
+
+    let category = by_name
+        .get("idx_session_flags_category")
+        .expect("missing idx_session_flags_category");
+    assert!(
+        category
+            .as_ref()
+            .map(|s| s.contains("WHERE category_l1 IS NOT NULL"))
+            .unwrap_or(false),
+        "category index lost its WHERE clause: {:?}",
+        category
+    );
+}
+
+#[tokio::test]
+async fn test_migration65_session_flags_applied_seq_default_zero() {
+    let pool = setup_db().await;
+    sqlx::query("INSERT INTO session_flags (session_id) VALUES ('seq-default')")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let row: (i64,) =
+        sqlx::query_as("SELECT applied_seq FROM session_flags WHERE session_id = 'seq-default'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        row.0, 0,
+        "applied_seq must default to 0 (Phase 5 fold start)"
+    );
+}

--- a/crates/db/src/queries/mod.rs
+++ b/crates/db/src/queries/mod.rs
@@ -16,12 +16,17 @@ pub mod search_prefilter;
 mod seed;
 pub mod sessions;
 pub mod settings;
+mod stats;
 mod system;
 mod types;
 
 pub use dashboard::ActivityPoint;
 pub use dashboard::{ActivitySummaryRow, ProjectActivityRow, RichActivityResponse};
 pub use search_prefilter::SearchPrefilter;
+// `stats::StatsHeader` is intentionally not re-exported in PR 2.1 — the
+// only caller (indexer_v2 in PR 2.2) lives inside `claude_view_db` itself
+// and reaches it via `crate::queries::stats`. Promoting to a public
+// re-export will happen when an external crate first needs the type.
 pub use types::*;
 
 // Re-export _tx functions used by the unified indexing pipeline.

--- a/crates/db/src/queries/stats/mod.rs
+++ b/crates/db/src/queries/stats/mod.rs
@@ -1,0 +1,145 @@
+// crates/db/src/queries/stats/mod.rs
+// Read-side accessors for the Phase 2 `session_stats` table.
+//
+// PR 2.1 only ships the staleness-header query; PR 2.2 adds the writer
+// (`upsert_session_stats`) and PR 3.x adds the full-row read for the
+// /api/sessions cutover. Keeping this module minimal until then.
+
+use crate::{Database, DbResult};
+use sqlx::Row;
+
+/// Staleness header for a single `session_stats` row.
+///
+/// Used by the indexer_v2 orchestrator (Phase 2 PR 2.2) to decide whether
+/// the source JSONL has changed since the last index — if the on-disk
+/// `(content_hash, size, inode, mid_hash)` matches and `parser_version` /
+/// `stats_version` are current, the parse is skipped.
+#[derive(Debug, Clone)]
+pub struct StatsHeader {
+    pub session_id: String,
+    pub source_content_hash: Vec<u8>,
+    pub source_size: i64,
+    pub source_inode: Option<i64>,
+    pub source_mid_hash: Option<Vec<u8>>,
+    pub parser_version: i64,
+    pub stats_version: i64,
+    pub indexed_at: i64,
+}
+
+impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for StatsHeader {
+    fn from_row(row: &'r sqlx::sqlite::SqliteRow) -> Result<Self, sqlx::Error> {
+        Ok(Self {
+            session_id: row.try_get("session_id")?,
+            source_content_hash: row.try_get("source_content_hash")?,
+            source_size: row.try_get("source_size")?,
+            source_inode: row.try_get("source_inode")?,
+            source_mid_hash: row.try_get("source_mid_hash")?,
+            parser_version: row.try_get("parser_version")?,
+            stats_version: row.try_get("stats_version")?,
+            indexed_at: row.try_get("indexed_at")?,
+        })
+    }
+}
+
+impl Database {
+    /// Fetch the staleness header for `session_id`, or `None` if the
+    /// session has never been indexed by the Phase 2 writer.
+    ///
+    /// `Option<StatsHeader>` — `None` is the explicit "never indexed"
+    /// signal that the indexer_v2 orchestrator interprets as "always
+    /// re-parse."
+    pub async fn get_stats_header(&self, session_id: &str) -> DbResult<Option<StatsHeader>> {
+        let header = sqlx::query_as::<_, StatsHeader>(
+            r#"SELECT session_id, source_content_hash, source_size, source_inode,
+                      source_mid_hash, parser_version, stats_version, indexed_at
+                 FROM session_stats
+                WHERE session_id = ?"#,
+        )
+        .bind(session_id)
+        .fetch_optional(self.pool())
+        .await?;
+        Ok(header)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Database;
+
+    #[tokio::test]
+    async fn get_stats_header_returns_none_for_unknown_session() {
+        let db = Database::new_in_memory().await.unwrap();
+        let header = db.get_stats_header("does-not-exist").await.unwrap();
+        assert!(
+            header.is_none(),
+            "unknown session must yield None, got {:?}",
+            header
+        );
+    }
+
+    #[tokio::test]
+    async fn get_stats_header_round_trips_inserted_row() {
+        let db = Database::new_in_memory().await.unwrap();
+
+        // Direct INSERT — the proper writer ships in PR 2.2; this test only
+        // pins the read path against a hand-written row that exercises every
+        // header column (incl. nullable inode + mid_hash).
+        sqlx::query(
+            r#"INSERT INTO session_stats (
+                   session_id, source_content_hash, source_size,
+                   source_inode, source_mid_hash,
+                   parser_version, stats_version, indexed_at
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"#,
+        )
+        .bind("sess-rt")
+        .bind(vec![0xDEu8, 0xAD, 0xBEu8, 0xEFu8])
+        .bind(4096_i64)
+        .bind(Some(1234567_i64))
+        .bind(Some(vec![0xCAu8, 0xFEu8]))
+        .bind(2_i64)
+        .bind(3_i64)
+        .bind(1_715_000_000_i64)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let header = db
+            .get_stats_header("sess-rt")
+            .await
+            .unwrap()
+            .expect("inserted row must be readable");
+        assert_eq!(header.session_id, "sess-rt");
+        assert_eq!(header.source_content_hash, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+        assert_eq!(header.source_size, 4096);
+        assert_eq!(header.source_inode, Some(1234567));
+        assert_eq!(header.source_mid_hash, Some(vec![0xCA, 0xFE]));
+        assert_eq!(header.parser_version, 2);
+        assert_eq!(header.stats_version, 3);
+        assert_eq!(header.indexed_at, 1_715_000_000);
+    }
+
+    #[tokio::test]
+    async fn get_stats_header_handles_nullable_columns() {
+        let db = Database::new_in_memory().await.unwrap();
+
+        sqlx::query(
+            r#"INSERT INTO session_stats (
+                   session_id, source_content_hash, source_size,
+                   parser_version, stats_version, indexed_at
+               ) VALUES (?, ?, ?, ?, ?, ?)"#,
+        )
+        .bind("sess-null")
+        .bind(vec![0x01u8])
+        .bind(1_i64)
+        .bind(1_i64)
+        .bind(1_i64)
+        .bind(0_i64)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let header = db.get_stats_header("sess-null").await.unwrap().unwrap();
+        assert_eq!(header.source_inode, None);
+        assert_eq!(header.source_mid_hash, None);
+    }
+}


### PR DESCRIPTION
## Summary

PR 2.1 of the CQRS Phase 2 redesign per [phase 1-7 design doc §3.1](../../private/config/docs/plans/2026-04-17-cqrs-phase-1-7-design.md). Lands the read-side schema (no reads cut over yet — that's PR 3.x). PR 2.2 will add the indexer_v2 writer that populates `session_stats`; Phase 5 will populate `session_flags`.

## What ships

**Migration 64 — `session_stats`** (32 cols, STRICT mode)
- 8 staleness/header (session_id PK + content/size/inode/mid_hash + parser/stats versions + indexed_at)
- 24 stats (6 tokens, 6 counts, 4 tools, 3 times, 4 strings, 1 per-model JSON)
- 5 indexes targeted at Phase 3 cutover queries: `last_message_at`, `indexed_at`, **expression index on `(total_input_tokens + total_output_tokens)`** (design said `total_tokens` — that column doesn't exist, so this is the minimum-surprise substitute documented inline), `primary_model`, `git_branch`
- No FK to `sessions` — shadow mode tolerates transient inconsistency per design

**Migration 65 — `session_flags`** (10 cols, STRICT mode)
- Append-only fold target for archive/dismiss/classify (Phase 5 adds the writer)
- All rows start with `applied_seq=0`
- 2 partial indexes: `archived_at` and `category_l1` (both `WHERE NOT NULL`)

**`crates/db/src/queries/stats/mod.rs`** (new module)
- `StatsHeader` struct (8 staleness fields, manual `FromRow` impl matching `facets.rs` / `hook_events.rs`)
- `Database::get_stats_header(session_id) -> DbResult<Option<StatsHeader>>` — `None` is the explicit \"never indexed\" signal that PR 2.2's orchestrator interprets as \"always re-parse\"
- Re-export from `queries::mod.rs` deliberately deferred — only in-crate caller (PR 2.2's indexer_v2)

## Tests added (10, all <100ms)

| Area | Test |
|---|---|
| migration 64 | columns_exist (full schema; **32 cols total**, design said 34 but miscounted) |
| migration 64 | strict_mode_rejects_text_in_int |
| migration 64 | indexes_created (5 of them) |
| migration 64 | default_row_inserts (validates DEFAULT clauses) |
| migration 65 | columns_exist (10 cols) |
| migration 65 | partial_indexes_created (verifies WHERE clauses survive sqlite_master round-trip) |
| migration 65 | applied_seq_default_zero |
| queries::stats | get_stats_header_returns_none_for_unknown_session |
| queries::stats | get_stats_header_round_trips_inserted_row |
| queries::stats | get_stats_header_handles_nullable_columns |

## Verification

| Gate | Result |
|---|---|
| `./scripts/cq test -p claude-view-db --lib` | **297/297 PASS** (10 new + 287 from PR 2.0 baseline) |
| `./scripts/cq clippy --workspace -- -D warnings -D deprecated` | green |
| Lefthook pre-push (clippy + cargo-deny + `cq test --workspace` + cq-nextest-routing) | all green in 142s |

## Design-doc deviations called out in code

1. **`total_tokens` index** — design referenced a column that doesn't exist; substituted an expression index on `(total_input_tokens + total_output_tokens) DESC`. Inline note in `features.rs`.
2. **Column count** — design said \"9 header + 25 stats = 34\"; actual schema is 8 + 24 = 32. The header miscounted (the 5 staleness fields together with parser/stats versions and indexed_at are 8, not 9). Test asserts the real count.

## Test plan
- [x] All db crate lib tests pass (297/297)
- [x] Workspace clippy green
- [x] Full workspace tests green (lefthook pre-push)
- [x] STRICT mode actually rejects type mismatches (test asserts INSERT fails with TEXT in INTEGER column)
- [x] Partial indexes preserve WHERE clauses (verified via sqlite_master.sql round-trip)
- [x] No external callers of `StatsHeader` left dangling (re-export deferred until PR 2.2 needs it)

## Next in the Phase 2 sequence
PR 2.2 (`feat(db): indexer_v2 shadow module`) — the writer that populates `session_stats` from JSONL via `claude_view_session_parser`. That's the bigger PR (~200 LOC, broadcast fanout from fsnotify, debouncer, TOCTOU retry loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)