### PR TITLE
fix(interact): confirmed-ack delivery — never clear pending on failed forward (Control v2 PR-1)

### DIFF
--- a/crates/server-sidecar/src/manager.rs
+++ b/crates/server-sidecar/src/manager.rs
@@ -57,6 +57,16 @@ impl SidecarManager {
         }
     }
 
+    /// Construct a manager pointed at an explicit base URL.
+    ///
+    /// For tests that need delivery to hit a mock sidecar (or a known-dead URL)
+    /// rather than the default `http://localhost:{SIDECAR_PORT}`.
+    pub fn with_base_url(base_url: String) -> Self {
+        let mut manager = Self::new();
+        manager.base_url = base_url;
+        manager
+    }
+
     /// Current spawn generation. Starts at 0, increments on every successful
     /// spawn. Control bindings created before a restart will have a smaller
     /// generation than this; callers use the mismatch to detect staleness.

--- a/crates/server/src/routes/interact/delivery.rs
+++ b/crates/server/src/routes/interact/delivery.rs
@@ -1,0 +1,270 @@
+//! Interaction delivery — forward a user's decision to the sidecar and confirm receipt.
+//!
+//! The Rust server is the single delivery authority for the REST `/interact` path.
+//! It POSTs the decision to the sidecar's `/api/sidecar/sessions/{id}/interact`
+//! bridge and reads the `{ ok }` ack. The caller (`interact_handler`) clears pending
+//! state ONLY on [`DeliveryOutcome::Delivered`] — never on a rejected or failed
+//! delivery — so a decision the agent never received is reported honestly instead of
+//! silently lost (寧願唔顯示，都唔顯示錯嘅嘢).
+//!
+//! Replaces the old `forward_to_sidecar`, which POSTed to a route that did not exist
+//! (`/api/sessions/{control_id}/message`: wrong mount, wrong id, no such route) and
+//! cleared pending state regardless of the 404 it always got.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use crate::state::AppState;
+use claude_view_types::InteractRequest;
+
+/// Outcome of attempting to deliver an interaction decision to the sidecar.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeliveryOutcome {
+    /// Sidecar applied the decision (HTTP 2xx + `{ ok: true }`). Safe to clear pending.
+    Delivered,
+    /// Sidecar reached, but the decision was not applied — unknown/stale `requestId`
+    /// (HTTP 2xx + `{ ok: false }`). Maps to 409; pending is NOT cleared (the SDK's
+    /// own turn-end clear is authoritative).
+    Rejected(String),
+    /// Delivery could not be confirmed — sidecar unreachable, timed out, returned a
+    /// non-2xx status, or there is no live control channel. Maps to 503; pending is
+    /// NOT cleared so the user can retry.
+    Failed(String),
+}
+
+#[derive(Deserialize)]
+struct AckResponse {
+    ok: bool,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+/// How long to wait for the sidecar to ack before declaring delivery failed.
+/// Short by design: a dead sidecar should surface a Retry quickly, not hang the request.
+const ACK_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Deliver an interaction decision for `session_id` to the sidecar.
+///
+/// Performs lazy control recovery first (resuming the session in the sidecar if a
+/// restart orphaned it), then POSTs the decision and interprets the ack. When there
+/// is no `live_manager` (test factories) the lazy-recovery step is skipped and the
+/// decision is POSTed directly.
+pub async fn deliver(state: &AppState, session_id: &str, req: &InteractRequest) -> DeliveryOutcome {
+    if let Some(live_manager) = state.live_manager.as_ref() {
+        if let Err(e) = live_manager
+            .ensure_session_control_alive(session_id, "interact")
+            .await
+        {
+            return DeliveryOutcome::Failed(format!("control channel unavailable: {e}"));
+        }
+    }
+
+    post_decision(
+        &reqwest::Client::new(),
+        state.sidecar.base_url(),
+        session_id,
+        req,
+        ACK_TIMEOUT,
+    )
+    .await
+}
+
+/// Pure HTTP delivery: POST the decision and map the response to an outcome.
+///
+/// Free function (no `AppState`) so the full delivery contract is unit-testable
+/// against a mock sidecar.
+pub async fn post_decision(
+    client: &reqwest::Client,
+    sidecar_base: &str,
+    session_id: &str,
+    req: &InteractRequest,
+    timeout: Duration,
+) -> DeliveryOutcome {
+    let url = format!("{sidecar_base}/api/sidecar/sessions/{session_id}/interact");
+    let body = build_sidecar_message(req);
+
+    let resp = match client.post(&url).json(&body).timeout(timeout).send().await {
+        Ok(resp) => resp,
+        Err(e) if e.is_timeout() => {
+            return DeliveryOutcome::Failed(format!("sidecar ack timed out after {timeout:?}"));
+        }
+        Err(e) => return DeliveryOutcome::Failed(format!("sidecar unreachable: {e}")),
+    };
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return DeliveryOutcome::Failed(format!("sidecar returned {status}: {body}"));
+    }
+
+    match resp.json::<AckResponse>().await {
+        Ok(ack) if ack.ok => DeliveryOutcome::Delivered,
+        Ok(ack) => DeliveryOutcome::Rejected(
+            ack.reason
+                .unwrap_or_else(|| "interaction not applied".into()),
+        ),
+        Err(e) => DeliveryOutcome::Failed(format!("malformed sidecar ack: {e}")),
+    }
+}
+
+/// Build the sidecar-compatible JSON body from an `InteractRequest`.
+/// Same wire shape the sidecar's interaction-resolver parses.
+fn build_sidecar_message(req: &InteractRequest) -> serde_json::Value {
+    match req {
+        InteractRequest::Permission {
+            request_id,
+            allowed,
+            updated_permissions,
+        } => {
+            let mut msg = serde_json::json!({
+                "type": "permission_response",
+                "requestId": request_id,
+                "allowed": allowed
+            });
+            if let Some(perms) = updated_permissions {
+                msg["updatedPermissions"] = serde_json::json!(perms);
+            }
+            msg
+        }
+        InteractRequest::Question {
+            request_id,
+            answers,
+        } => serde_json::json!({
+            "type": "question_response",
+            "requestId": request_id,
+            "answers": answers
+        }),
+        InteractRequest::Plan {
+            request_id,
+            approved,
+            feedback,
+            bypass_permissions,
+        } => {
+            let mut msg = serde_json::json!({
+                "type": "plan_response",
+                "requestId": request_id,
+                "approved": approved
+            });
+            if let Some(fb) = feedback {
+                msg["feedback"] = serde_json::json!(fb);
+            }
+            if let Some(bp) = bypass_permissions {
+                msg["bypassPermissions"] = serde_json::json!(bp);
+            }
+            msg
+        }
+        InteractRequest::Elicitation {
+            request_id,
+            response,
+        } => serde_json::json!({
+            "type": "elicitation_response",
+            "requestId": request_id,
+            "response": response
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{http::StatusCode, routing::post, Json, Router};
+
+    fn permission_req() -> InteractRequest {
+        InteractRequest::Permission {
+            request_id: "req-1".to_string(),
+            allowed: true,
+            updated_permissions: None,
+        }
+    }
+
+    /// Spawn a mock sidecar that answers the interact route with `(status, body)`.
+    /// Returns its base URL (e.g. `http://127.0.0.1:54321`).
+    async fn spawn_mock_sidecar(status: StatusCode, body: serde_json::Value) -> String {
+        let app = Router::new().route(
+            "/api/sidecar/sessions/{id}/interact",
+            post(move || {
+                let body = body.clone();
+                async move { (status, Json(body)) }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn delivered_when_ack_ok_true() {
+        let base = spawn_mock_sidecar(StatusCode::OK, serde_json::json!({ "ok": true })).await;
+        let outcome = post_decision(
+            &reqwest::Client::new(),
+            &base,
+            "sess-1",
+            &permission_req(),
+            Duration::from_secs(2),
+        )
+        .await;
+        assert_eq!(outcome, DeliveryOutcome::Delivered);
+    }
+
+    #[tokio::test]
+    async fn rejected_when_ack_ok_false() {
+        let base = spawn_mock_sidecar(
+            StatusCode::OK,
+            serde_json::json!({ "ok": false, "reason": "Unknown permission requestId" }),
+        )
+        .await;
+        let outcome = post_decision(
+            &reqwest::Client::new(),
+            &base,
+            "sess-1",
+            &permission_req(),
+            Duration::from_secs(2),
+        )
+        .await;
+        assert_eq!(
+            outcome,
+            DeliveryOutcome::Rejected("Unknown permission requestId".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_on_non_2xx() {
+        let base = spawn_mock_sidecar(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            serde_json::json!({ "error": "boom" }),
+        )
+        .await;
+        let outcome = post_decision(
+            &reqwest::Client::new(),
+            &base,
+            "sess-1",
+            &permission_req(),
+            Duration::from_secs(2),
+        )
+        .await;
+        assert!(matches!(outcome, DeliveryOutcome::Failed(_)));
+    }
+
+    #[tokio::test]
+    async fn failed_when_sidecar_unreachable() {
+        // Bind then drop a listener to obtain a definitely-closed port.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let base = format!("http://{addr}");
+
+        let outcome = post_decision(
+            &reqwest::Client::new(),
+            &base,
+            "sess-1",
+            &permission_req(),
+            Duration::from_secs(2),
+        )
+        .await;
+        assert!(matches!(outcome, DeliveryOutcome::Failed(_)));
+    }
+}

--- a/crates/server/src/routes/interact/handlers.rs
+++ b/crates/server/src/routes/interact/handlers.rs
@@ -12,6 +12,7 @@ use axum::{
 
 use crate::error::{ApiError, ApiResult};
 use crate::live::mutation::types::{InteractionAction, SessionMutation};
+use crate::routes::interact::delivery::{self, DeliveryOutcome};
 use crate::state::AppState;
 use claude_view_types::{InteractRequest, InteractionBlock};
 
@@ -90,22 +91,28 @@ pub async fn get_interaction_handler(
 
 /// Resolve a pending interaction (permission, question, plan, elicitation).
 ///
-/// 1. Parse InteractRequest from body
-/// 2. Look up session in live_sessions — 404 if not found
-/// 3. Resolve ownership — 400 if Observed
-/// 4. Check interaction_data side-map — 409 if request_id not found (stale)
-/// 5. For SDK: forward to sidecar HTTP API
-/// 6. Clear pending interaction via coordinator
+/// 1. Look up session in live_sessions — 404 if not found
+/// 2. Require an SDK control channel — 400 if observed (read-only mirror) or
+///    tmux-only (a CLI session is driven by forking, never by writing into it)
+/// 3. Check interaction_data side-map — 409 if request_id not found (stale)
+/// 4. Deliver to the sidecar and await its ack, then:
+///    - Delivered  → clear pending + 200
+///    - Rejected   → 409, pending retained (SDK turn-end is authoritative)
+///    - Failed     → 503, pending retained for retry
+///
+/// Pending state is cleared ONLY on confirmed delivery: a decision the agent
+/// never received must never be reported as resolved (寧願唔顯示，都唔顯示錯嘅嘢).
 #[utoipa::path(
     post,
     path = "/api/sessions/{session_id}/interact",
     tag = "sessions",
     params(("session_id" = String, Path, description = "Session UUID")),
     responses(
-        (status = 200, description = "Interaction resolved"),
-        (status = 400, description = "Observed session or invalid request"),
+        (status = 200, description = "Interaction delivered and resolved"),
+        (status = 400, description = "Observed/tmux-only session — no SDK control channel"),
         (status = 404, description = "Session not found"),
-        (status = 409, description = "Request ID stale or already resolved"),
+        (status = 409, description = "Request ID stale, or sidecar reported it already resolved"),
+        (status = 503, description = "Delivery to the controlling sidecar could not be confirmed"),
     )
 )]
 pub async fn interact_handler(
@@ -115,7 +122,7 @@ pub async fn interact_handler(
 ) -> ApiResult<Json<serde_json::Value>> {
     let request_id = extract_request_id(&req).to_string();
 
-    // Step 2: session exists? Clone and drop lock before async compute.
+    // Step 1: session exists? Clone and drop lock before async work.
     let session_clone = {
         let sessions = state.live_sessions.read().await;
         sessions
@@ -125,14 +132,17 @@ pub async fn interact_handler(
     };
     let ownership = crate::live::ownership::compute_ownership(&session_clone);
 
-    // Step 3: check ownership — can interact if tmux or sdk binding exists
-    if ownership.tmux.is_none() && ownership.sdk.is_none() {
+    // Step 2: require an SDK control channel. Observed sessions are read-only
+    // mirrors of the CLI; a tmux-owned CLI session is driven by *forking* it
+    // (take-over), never by injecting a response into the CLI's own lineage.
+    if ownership.sdk.is_none() {
         return Err(ApiError::BadRequest(
-            "Cannot interact with an observed session — no control channel available".to_string(),
+            "Cannot interact with this session — no SDK control channel (take over to drive it)"
+                .to_string(),
         ));
     }
 
-    // Step 4: check side-map for request_id (stale check)
+    // Step 3: side-map must still hold this request_id (else stale / already resolved).
     {
         let data = state.interaction_data.read().await;
         if !data.contains_key(&request_id) {
@@ -142,140 +152,35 @@ pub async fn interact_handler(
         }
     }
 
-    // Step 5: dispatch based on ownership
-    let sidecar_forwarded = if ownership.sdk.is_some() {
-        match forward_to_sidecar(&state, &session_id, &req).await {
-            Ok(()) => true,
-            Err(e) => {
-                tracing::warn!(
-                    session_id,
-                    request_id = %request_id,
-                    error = %e,
-                    "Sidecar forward failed — state cleared but sidecar not notified"
-                );
-                false
-            }
-        }
-    } else if ownership.tmux.is_some() {
-        // TODO(Task 10+): forward keystroke via tmux send-keys.
-        true
-    } else {
-        unreachable!("guarded above")
-    };
-
-    // Step 6: clear pending interaction regardless of sidecar result.
-    // The user made their decision — don't leave stale pending state.
-    clear_pending_interaction(&state, &session_id, &request_id).await;
-
-    // Always return 200 — the interaction is resolved from the server's
-    // perspective. The sidecarForwarded flag lets the frontend know if
-    // the ConversationView WS path needs to deliver the response instead.
-    Ok(Json(serde_json::json!({
-        "resolved": true,
-        "requestId": request_id,
-        "sessionId": session_id,
-        "sidecarForwarded": sidecar_forwarded
-    })))
-}
-
-/// Forward the interaction resolution to the sidecar HTTP API.
-///
-/// Uses lazy recovery: resolves the session's current valid control_id
-/// (resuming in the sidecar if the previous one was orphaned by a restart).
-async fn forward_to_sidecar(
-    state: &AppState,
-    session_id: &str,
-    req: &InteractRequest,
-) -> Result<(), String> {
-    let live_manager = state
-        .live_manager
-        .as_ref()
-        .ok_or_else(|| "Live manager not initialized".to_string())?;
-    let control_id = live_manager
-        .ensure_session_control_alive(session_id, "interact")
-        .await
-        .map_err(|e| format!("Sidecar not available: {e}"))?;
-    let sidecar_base = state.sidecar.base_url().to_string();
-
-    let url = format!("{sidecar_base}/api/sessions/{control_id}/message");
-
-    // Build the sidecar message from the InteractRequest.
-    let sidecar_body = build_sidecar_message(req);
-
-    let client = reqwest::Client::new();
-    let resp = client
-        .post(&url)
-        .json(&sidecar_body)
-        .timeout(std::time::Duration::from_secs(10))
-        .send()
-        .await
-        .map_err(|e| format!("Sidecar HTTP request failed: {e}"))?;
-
-    if resp.status().is_success() {
-        Ok(())
-    } else {
-        let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
-        Err(format!("Sidecar returned {status}: {body}"))
-    }
-}
-
-/// Build a sidecar-compatible JSON message from an InteractRequest.
-fn build_sidecar_message(req: &InteractRequest) -> serde_json::Value {
-    match req {
-        InteractRequest::Permission {
-            request_id,
-            allowed,
-            updated_permissions,
-        } => {
-            let mut msg = serde_json::json!({
-                "type": "permission_response",
+    // Step 4: deliver to the controlling sidecar and confirm receipt.
+    match delivery::deliver(&state, &session_id, &req).await {
+        DeliveryOutcome::Delivered => {
+            clear_pending_interaction(&state, &session_id, &request_id).await;
+            Ok(Json(serde_json::json!({
+                "resolved": true,
                 "requestId": request_id,
-                "allowed": allowed
-            });
-            if let Some(perms) = updated_permissions {
-                msg["updatedPermissions"] = serde_json::json!(perms);
-            }
-            msg
+                "sessionId": session_id,
+            })))
         }
-        InteractRequest::Question {
-            request_id,
-            answers,
-        } => {
-            serde_json::json!({
-                "type": "question_response",
-                "requestId": request_id,
-                "answers": answers
-            })
+        DeliveryOutcome::Rejected(reason) => {
+            // Sidecar reached, but the decision didn't apply (unknown/stale id).
+            // The SDK's own turn-end clear is authoritative — don't clear here.
+            Err(ApiError::Conflict(format!(
+                "Interaction already resolved or unknown: {reason}"
+            )))
         }
-        InteractRequest::Plan {
-            request_id,
-            approved,
-            feedback,
-            bypass_permissions,
-        } => {
-            let mut msg = serde_json::json!({
-                "type": "plan_response",
-                "requestId": request_id,
-                "approved": approved
-            });
-            if let Some(fb) = feedback {
-                msg["feedback"] = serde_json::json!(fb);
-            }
-            if let Some(bp) = bypass_permissions {
-                msg["bypassPermissions"] = serde_json::json!(bp);
-            }
-            msg
-        }
-        InteractRequest::Elicitation {
-            request_id,
-            response,
-        } => {
-            serde_json::json!({
-                "type": "elicitation_response",
-                "requestId": request_id,
-                "response": response
-            })
+        DeliveryOutcome::Failed(reason) => {
+            // Delivery unconfirmed — keep pending so the user can retry. The
+            // decision is NOT silently lost or falsely reported as resolved.
+            tracing::warn!(
+                session_id,
+                request_id = %request_id,
+                reason = %reason,
+                "Interaction delivery failed — pending retained for retry"
+            );
+            Err(ApiError::ServiceUnavailable(format!(
+                "Could not deliver decision to the controlling agent: {reason}"
+            )))
         }
     }
 }

--- a/crates/server/src/routes/interact/mod.rs
+++ b/crates/server/src/routes/interact/mod.rs
@@ -6,6 +6,7 @@
 //! - POST /sessions/{session_id}/interact    — resolve a pending interaction
 //! - GET  /sessions/{session_id}/interaction  — fetch full interaction block
 
+pub mod delivery;
 pub mod handlers;
 
 // Re-export handlers for openapi.rs path annotations.

--- a/crates/server/src/routes/interact/tests.rs
+++ b/crates/server/src/routes/interact/tests.rs
@@ -29,6 +29,45 @@ async fn test_state() -> std::sync::Arc<AppState> {
     AppState::new(db)
 }
 
+/// Helper: test AppState whose sidecar delivery is pointed at `base_url`
+/// (a mock sidecar or a known-dead URL).
+async fn test_state_with_sidecar(base_url: String) -> std::sync::Arc<AppState> {
+    let db = claude_view_db::Database::new_in_memory()
+        .await
+        .expect("in-memory DB");
+    AppState::builder(db)
+        .with_sidecar(std::sync::Arc::new(
+            crate::sidecar::SidecarManager::with_base_url(base_url),
+        ))
+        .build()
+}
+
+/// Spawn a mock sidecar that answers the interact bridge with `(status, body)`.
+/// Returns its base URL.
+async fn spawn_mock_sidecar(status: StatusCode, body: serde_json::Value) -> String {
+    let app = axum::Router::new().route(
+        "/api/sidecar/sessions/{id}/interact",
+        axum::routing::post(move || {
+            let body = body.clone();
+            async move { (status, axum::Json(body)) }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+/// A base URL whose port is closed — delivery to it fails (connection refused).
+async fn dead_sidecar_url() -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    format!("http://{addr}")
+}
+
 /// Helper: insert a live session into the state's live_sessions map.
 async fn insert_live_session(state: &AppState, id: &str) {
     let session = claude_view_server_live_state::core::test_live_session(id);
@@ -257,24 +296,15 @@ async fn post_interact_returns_400_for_observed_sessions() {
 }
 
 #[tokio::test]
-async fn post_interact_clears_pending_on_success_sdk() {
-    let state = test_state().await;
+async fn post_interact_clears_pending_when_delivered() {
+    // Mock sidecar acks the decision → handler clears pending + returns 200.
+    let base = spawn_mock_sidecar(StatusCode::OK, json!({ "ok": true })).await;
+    let state = test_state_with_sidecar(base).await;
     insert_sdk_session(&state, "sess-005", "ctl-xyz").await;
     set_pending_interaction(&state, "sess-005", "req-300").await;
 
-    // Verify pending is set before
-    {
-        let sessions = state.live_sessions.read().await;
-        assert!(sessions["sess-005"].pending_interaction.is_some());
-    }
-    assert!(state.interaction_data.read().await.contains_key("req-300"));
-
     let app = test_router(state.clone());
-    let body = json!({
-        "variant": "permission",
-        "requestId": "req-300",
-        "allowed": true
-    });
+    let body = json!({ "variant": "permission", "requestId": "req-300", "allowed": true });
     let resp = app
         .oneshot(
             Request::builder()
@@ -287,30 +317,90 @@ async fn post_interact_clears_pending_on_success_sdk() {
         .await
         .unwrap();
 
-    // The handler always returns 200 — state is cleared regardless of
-    // whether sidecar forward succeeded. The `sidecarForwarded` field
-    // tells the frontend if the sidecar got the message.
     assert_eq!(resp.status(), StatusCode::OK);
-
-    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
         .await
         .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(json["resolved"], true);
     assert_eq!(json["requestId"], "req-300");
     assert_eq!(json["sessionId"], "sess-005");
+    // No sidecarForwarded field anymore — 200 means actually delivered.
+    assert!(json.get("sidecarForwarded").is_none());
 
-    // Verify pending cleared from session
+    // Pending cleared only because delivery was confirmed.
+    {
+        let sessions = state.live_sessions.read().await;
+        assert!(sessions["sess-005"].pending_interaction.is_none());
+    }
+    assert!(!state.interaction_data.read().await.contains_key("req-300"));
+}
+
+#[tokio::test]
+async fn post_interact_keeps_pending_when_delivery_fails() {
+    // THE regression guard: a failed delivery must NEVER report resolved and
+    // must NEVER clear pending (寧願唔顯示，都唔顯示錯嘅嘢). Sidecar is dead.
+    let base = dead_sidecar_url().await;
+    let state = test_state_with_sidecar(base).await;
+    insert_sdk_session(&state, "sess-006", "ctl-dead").await;
+    set_pending_interaction(&state, "sess-006", "req-301").await;
+
+    let app = test_router(state.clone());
+    let body = json!({ "variant": "permission", "requestId": "req-301", "allowed": true });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/sess-006/interact")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    // Pending retained so the user can retry — decision not silently lost.
     {
         let sessions = state.live_sessions.read().await;
         assert!(
-            sessions["sess-005"].pending_interaction.is_none(),
-            "pending_interaction should be cleared after interact"
+            sessions["sess-006"].pending_interaction.is_some(),
+            "pending_interaction MUST be retained when delivery fails"
         );
     }
-    // Verify side-map entry removed
     assert!(
-        !state.interaction_data.read().await.contains_key("req-300"),
-        "interaction_data side-map should be cleared after interact"
+        state.interaction_data.read().await.contains_key("req-301"),
+        "side-map entry MUST be retained when delivery fails"
     );
+}
+
+#[tokio::test]
+async fn post_interact_keeps_pending_when_sidecar_rejects() {
+    // Sidecar reached but reports the requestId unknown/stale → 409, no clear.
+    let base = spawn_mock_sidecar(
+        StatusCode::OK,
+        json!({ "ok": false, "reason": "Unknown permission requestId" }),
+    )
+    .await;
+    let state = test_state_with_sidecar(base).await;
+    insert_sdk_session(&state, "sess-007", "ctl-rej").await;
+    set_pending_interaction(&state, "sess-007", "req-302").await;
+
+    let app = test_router(state.clone());
+    let body = json!({ "variant": "permission", "requestId": "req-302", "allowed": false });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/sess-007/interact")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    // The SDK's own turn-end clear is authoritative — the handler does not clear.
+    assert!(state.interaction_data.read().await.contains_key("req-302"));
 }

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -243,6 +243,7 @@ pub struct AppStateBuilder {
     indexing: Option<Arc<IndexingState>>,
     registry: Option<RegistryHolder>,
     shutdown: Option<tokio::sync::watch::Receiver<bool>>,
+    sidecar: Option<Arc<SidecarManager>>,
 }
 
 impl AppStateBuilder {
@@ -261,6 +262,13 @@ impl AppStateBuilder {
     /// Override the shutdown watch receiver.
     pub fn with_shutdown(mut self, shutdown: tokio::sync::watch::Receiver<bool>) -> Self {
         self.shutdown = Some(shutdown);
+        self
+    }
+
+    /// Override the sidecar manager (e.g. tests pointing delivery at a mock
+    /// sidecar via `SidecarManager::with_base_url`).
+    pub fn with_sidecar(mut self, sidecar: Arc<SidecarManager>) -> Self {
+        self.sidecar = Some(sidecar);
         self
     }
 
@@ -327,7 +335,9 @@ impl AppStateBuilder {
                 .shutdown
                 .unwrap_or_else(|| tokio::sync::watch::channel(false).1),
             hook_event_channels: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
-            sidecar: Arc::new(SidecarManager::new()),
+            sidecar: self
+                .sidecar
+                .unwrap_or_else(|| Arc::new(SidecarManager::new())),
             terminal_manager: Arc::new(TerminalManager::new()),
             session_catalog: legacy_catalog,
             session_catalog_adapter,
@@ -390,6 +400,7 @@ impl AppState {
             indexing: None,
             registry: None,
             shutdown: None,
+            sidecar: None,
         }
     }
 

--- a/packages/plugin/scripts/openapi.json
+++ b/packages/plugin/scripts/openapi.json
@@ -4125,7 +4125,7 @@
           "sessions"
         ],
         "summary": "Resolve a pending interaction (permission, question, plan, elicitation).",
-        "description": "1. Parse InteractRequest from body\n2. Look up session in live_sessions — 404 if not found\n3. Resolve ownership — 400 if Observed\n4. Check interaction_data side-map — 409 if request_id not found (stale)\n5. For SDK: forward to sidecar HTTP API\n6. Clear pending interaction via coordinator",
+        "description": "1. Look up session in live_sessions — 404 if not found\n2. Require an SDK control channel — 400 if observed (read-only mirror) or\n   tmux-only (a CLI session is driven by forking, never by writing into it)\n3. Check interaction_data side-map — 409 if request_id not found (stale)\n4. Deliver to the sidecar and await its ack, then:\n   - Delivered  → clear pending + 200\n   - Rejected   → 409, pending retained (SDK turn-end is authoritative)\n   - Failed     → 503, pending retained for retry\n\nPending state is cleared ONLY on confirmed delivery: a decision the agent\nnever received must never be reported as resolved (寧願唔顯示，都唔顯示錯嘅嘢).",
         "operationId": "interact_handler",
         "parameters": [
           {
@@ -4150,16 +4150,19 @@
         },
         "responses": {
           "200": {
-            "description": "Interaction resolved"
+            "description": "Interaction delivered and resolved"
           },
           "400": {
-            "description": "Observed session or invalid request"
+            "description": "Observed/tmux-only session — no SDK control channel"
           },
           "404": {
             "description": "Session not found"
           },
           "409": {
-            "description": "Request ID stale or already resolved"
+            "description": "Request ID stale, or sidecar reported it already resolved"
+          },
+          "503": {
+            "description": "Delivery to the controlling sidecar could not be confirmed"
           }
         }
       }

--- a/sidecar/src/interaction-resolver.ts
+++ b/sidecar/src/interaction-resolver.ts
@@ -1,0 +1,78 @@
+// sidecar/src/interaction-resolver.ts
+// Single resolution primitive for frontend interaction decisions.
+//
+// Both transports converge here:
+//   - the control WebSocket (`ws-handler.ts`, used by the in-app chat panel), and
+//   - the REST delivery bridge (`POST /api/sidecar/sessions/:id/interact`, used by
+//     the Rust server for monitor/mobile surfaces that have no live control WS).
+//
+// Returning one `{ ok }` shape from one function keeps the two paths from drifting
+// (one-architecture-per-concern) and gives the Rust server an explicit delivery ack
+// so it only clears pending state once a decision was actually applied.
+import type { PermissionUpdate } from '@anthropic-ai/claude-agent-sdk'
+import type {
+  ElicitationResponse,
+  PermissionResponse,
+  PlanResponseMsg,
+  QuestionResponse,
+} from './protocol.js'
+import type { ControlSession } from './session-registry.js'
+
+/** A user's decision on a pending interaction, delivered over WS or REST. */
+export type InteractionResponse =
+  | PermissionResponse
+  | QuestionResponse
+  | PlanResponseMsg
+  | ElicitationResponse
+
+/** Outcome of applying a decision. `ok:false` means the requestId was unknown
+ *  (already resolved, aborted, or stale) — the caller must NOT report success. */
+export interface ResolveResult {
+  ok: boolean
+  reason?: string
+}
+
+/**
+ * Apply a frontend decision to the session's matching pending request.
+ *
+ * Never throws: an unknown `requestId` returns `{ ok: false, reason }` so the
+ * caller can surface "already resolved" rather than fabricate an outcome.
+ */
+export function resolveInteraction(
+  session: ControlSession,
+  msg: InteractionResponse,
+): ResolveResult {
+  const { permissions } = session
+  switch (msg.type) {
+    case 'permission_response':
+      return permissions.resolvePermission(
+        msg.requestId,
+        msg.allowed,
+        msg.updatedPermissions as PermissionUpdate[] | undefined,
+      )
+        ? { ok: true }
+        : { ok: false, reason: 'Unknown permission requestId' }
+    case 'question_response':
+      return permissions.resolveQuestion(msg.requestId, msg.answers)
+        ? { ok: true }
+        : { ok: false, reason: 'Unknown question requestId' }
+    case 'plan_response':
+      return permissions.resolvePlan(
+        msg.requestId,
+        msg.approved,
+        msg.feedback,
+        msg.bypassPermissions,
+      )
+        ? { ok: true }
+        : { ok: false, reason: 'Unknown plan requestId' }
+    case 'elicitation_response':
+      return permissions.resolveElicitation(msg.requestId, msg.response)
+        ? { ok: true }
+        : { ok: false, reason: 'Unknown elicitation requestId' }
+    default:
+      return {
+        ok: false,
+        reason: `Unsupported interaction type: ${(msg as { type?: string }).type}`,
+      }
+  }
+}

--- a/sidecar/src/routes.test.ts
+++ b/sidecar/src/routes.test.ts
@@ -212,4 +212,89 @@ describe('routes', () => {
       expect(mockWaitForSessionInit).toHaveBeenCalledWith(cs, 15_000)
     })
   })
+
+  describe('POST /sessions/:id/interact', () => {
+    // Stub the four resolve* methods so we can assert routing + the {ok} ack
+    // without standing up a real PermissionHandler / SDK session.
+    function makeInteractiveCs(sessionId: string, resolves: Record<string, boolean>) {
+      return makeStubCs({
+        controlId: `ctrl-${sessionId}`,
+        sessionId,
+        // biome-ignore lint/suspicious/noExplicitAny: stubbed PermissionHandler
+        permissions: {
+          resolvePermission: vi.fn().mockReturnValue(resolves.permission ?? true),
+          resolveQuestion: vi.fn().mockReturnValue(resolves.question ?? true),
+          resolvePlan: vi.fn().mockReturnValue(resolves.plan ?? true),
+          resolveElicitation: vi.fn().mockReturnValue(resolves.elicitation ?? true),
+          drainAll: vi.fn(),
+        } as any,
+      })
+    }
+
+    it('resolves a pending permission and returns {ok:true}', async () => {
+      const app = createRoutes(registry)
+      const cs = makeInteractiveCs('sess-int-1', { permission: true })
+      registry.register(cs)
+
+      const res = await app.request('/sessions/sess-int-1/interact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'permission_response', requestId: 'req-1', allowed: true }),
+      })
+
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ ok: true })
+      expect(cs.permissions.resolvePermission).toHaveBeenCalledWith('req-1', true, undefined)
+    })
+
+    it('returns {ok:false} (200) when the requestId is unknown/stale', async () => {
+      const app = createRoutes(registry)
+      const cs = makeInteractiveCs('sess-int-2', { permission: false })
+      registry.register(cs)
+
+      const res = await app.request('/sessions/sess-int-2/interact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'permission_response', requestId: 'stale', allowed: false }),
+      })
+
+      // Delivery reached the sidecar (200) but the decision was not applied (ok:false).
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ ok: false, reason: 'Unknown permission requestId' })
+    })
+
+    it('routes question_response to resolveQuestion', async () => {
+      const app = createRoutes(registry)
+      const cs = makeInteractiveCs('sess-int-3', { question: true })
+      registry.register(cs)
+
+      const res = await app.request('/sessions/sess-int-3/interact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'question_response',
+          requestId: 'q-1',
+          answers: { color: 'blue' },
+        }),
+      })
+
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ ok: true })
+      expect(cs.permissions.resolveQuestion).toHaveBeenCalledWith('q-1', { color: 'blue' })
+    })
+
+    it('returns 404 {ok:false} when the session is not active in the sidecar', async () => {
+      const app = createRoutes(registry)
+      // nothing registered for this id
+
+      const res = await app.request('/sessions/missing/interact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'permission_response', requestId: 'req-x', allowed: true }),
+      })
+
+      expect(res.status).toBe(404)
+      expect(await res.json()).toMatchObject({ ok: false })
+    })
+  })
 })

--- a/sidecar/src/routes.ts
+++ b/sidecar/src/routes.ts
@@ -1,6 +1,7 @@
 // sidecar/src/routes.ts
 import { Hono } from 'hono'
 import { notifyBindControl, notifyUnbindControl } from './control-binding.js'
+import { type InteractionResponse, resolveInteraction } from './interaction-resolver.js'
 import { getCacheState } from './model-cache.js'
 import type { CreateSessionRequest, ForkSessionRequest, ResumeSessionRequest } from './protocol.js'
 import {
@@ -94,6 +95,26 @@ export function createRoutes(registry: SessionRegistry) {
     } catch (err) {
       return c.json({ error: `Fork failed: ${err instanceof Error ? err.message : err}` }, 500)
     }
+  })
+
+  // Resolve a pending interaction (permission / question / plan / elicitation).
+  //
+  // REST delivery bridge for surfaces with no live control WS (live monitor,
+  // mobile). The Rust server POSTs the decision here and reads the {ok} ack to
+  // decide whether to clear its pending state — so a decision that never lands
+  // (session gone, unknown requestId) is reported honestly instead of silently
+  // dropped. Keyed by sessionId, matching the other /sessions/:id routes.
+  app.post('/sessions/:id/interact', async (c) => {
+    const sessionId = c.req.param('id')
+    const cs = registry.getBySessionId(sessionId)
+    if (!cs) {
+      return c.json({ ok: false, reason: 'Session not active in sidecar' }, 404)
+    }
+    const msg = await c.req.json<InteractionResponse>().catch(() => null)
+    if (!msg || typeof msg.type !== 'string') {
+      return c.json({ ok: false, reason: 'Invalid interaction body' }, 400)
+    }
+    return c.json(resolveInteraction(cs, msg))
   })
 
   // List active control sessions (lightweight — no SDK calls)

--- a/sidecar/src/ws-handler.ts
+++ b/sidecar/src/ws-handler.ts
@@ -1,7 +1,7 @@
 // sidecar/src/ws-handler.ts
-import type { PermissionUpdate } from '@anthropic-ai/claude-agent-sdk'
 import type { WebSocket } from 'ws'
 import { normalizeNameArray } from './event-mapper.js'
+import { resolveInteraction } from './interaction-resolver.js'
 import type { ClientMessage, ServerEvent } from './protocol.js'
 import { sendMessage, setSessionMode } from './sdk-session.js'
 import type { SessionRegistry } from './session-registry.js'
@@ -129,62 +129,25 @@ export function handleWebSocket(ws: WebSocket, controlId: string, registry: Sess
           sendMessage(session, msg.content)
           break
 
+        // All four interaction decisions share one resolution primitive
+        // (interaction-resolver.ts), so the WS path and the REST delivery
+        // bridge can never drift. An unknown requestId returns {ok:false}.
         case 'permission_response':
-          if (
-            !session.permissions.resolvePermission(
-              msg.requestId,
-              msg.allowed,
-              msg.updatedPermissions as PermissionUpdate[] | undefined,
-            )
-          ) {
-            ws.send(
-              JSON.stringify({
-                type: 'error',
-                message: 'Unknown permission requestId',
-                fatal: false,
-              }),
-            )
-          }
-          break
-
         case 'question_response':
-          if (!session.permissions.resolveQuestion(msg.requestId, msg.answers)) {
-            ws.send(
-              JSON.stringify({
-                type: 'error',
-                message: 'Unknown question requestId',
-                fatal: false,
-              }),
-            )
-          }
-          break
-
         case 'plan_response':
-          if (
-            !session.permissions.resolvePlan(
-              msg.requestId,
-              msg.approved,
-              msg.feedback,
-              msg.bypassPermissions,
-            )
-          ) {
-            ws.send(
-              JSON.stringify({ type: 'error', message: 'Unknown plan requestId', fatal: false }),
-            )
-          }
-          break
-
-        case 'elicitation_response':
-          if (!session.permissions.resolveElicitation(msg.requestId, msg.response)) {
+        case 'elicitation_response': {
+          const result = resolveInteraction(session, msg)
+          if (!result.ok) {
             ws.send(
               JSON.stringify({
                 type: 'error',
-                message: 'Unknown elicitation requestId',
+                message: result.reason ?? 'Unknown requestId',
                 fatal: false,
               }),
             )
           }
           break
+        }
 
         case 'ping':
           ws.send(JSON.stringify({ type: 'pong' }))


### PR DESCRIPTION
## Control v2 — Pillar 3 (trustworthy interaction)

**Root cause.** The REST `/interact` path was structurally dead: `forward_to_sidecar` POSTed to `{base}/api/sessions/{control_id}/message`, but the sidecar mounts routes under `/api/sidecar` and defines **no `message` route**. Every monitor/mobile permission/answer 404'd, came back `sidecarForwarded:false` (which no frontend reads), yet pending state was cleared anyway — the user saw "Allowed" while the agent never received the decision.

**Fix — one delivery authority with an ack-before-clear contract:**
- **sidecar**: new `POST /api/sidecar/sessions/:id/interact` bridge returning `{ok,reason}`; new shared `resolveInteraction()` primitive; the control-WS handler refactored onto it so both transports can't drift.
- **server**: new `routes/interact/delivery.rs` (`DeliveryOutcome` Delivered/Rejected/Failed). `interact_handler` clears pending **only** on confirmed `Delivered` — `409` on reject (SDK turn-end stays authoritative), `503` on failure with pending retained for retry. Deleted dead `forward_to_sidecar` + the tmux send-keys stub (a CLI session is driven by *forking*, never by writing into its lineage).
- regen OpenAPI (added 503; dropped `sidecarForwarded`).

**Verification:** 32 server tests incl. the regression guard (failed delivery → 503, pending retained) + 4 delivery-contract unit tests; 44 sidecar tests. Full local pre-push gate green (`clippy --workspace -D warnings`, workspace `rust-test`, `cargo-deny`, `openapi-drift`).

寧願唔顯示，都唔顯示錯嘅嘢.

🤖 Generated with [Claude Code](https://claude.com/claude-code)