### PR TITLE
feat(takeover): re-enable CLI→GUI take-over via fork (Control v2 PR-3)

### DIFF
--- a/apps/web/src/components/chat/ChatPanel.tsx
+++ b/apps/web/src/components/chat/ChatPanel.tsx
@@ -60,8 +60,11 @@ export function ChatPanel({ params, api }: IDockviewPanelProps<ChatPanelParams>)
     return () => disposable.dispose()
   }, [api])
 
-  // Called when ChatSession creates a new session from the blank "New Chat" panel.
-  // Transitions this panel from blank to the real session.
+  // Called when the FSM's panel session id diverges from this panel's prop:
+  //   - blank "New Chat" panel creates a session, or
+  //   - a watched CLI session is TAKEN OVER (forked) into a new SDK session id.
+  // Either way, point this dockview panel + the router URL at the new id. The
+  // original CLI session stays in the live list (sidebar) and keeps streaming.
   const onSessionCreated = useCallback(
     (newSessionId: string) => {
       api.updateParameters({ sessionId: newSessionId })
@@ -88,7 +91,7 @@ export function ChatPanel({ params, api }: IDockviewPanelProps<ChatPanelParams>)
         ownership={ownership ?? null}
         liveProjectPath={liveProjectPath}
         liveContextData={liveContextData}
-        onSessionCreated={!sessionId ? onSessionCreated : undefined}
+        onSessionCreated={onSessionCreated}
         scrollToBottomSignal={scrollSignal}
       />
     </div>

--- a/apps/web/src/components/chat/WatchingBanner.tsx
+++ b/apps/web/src/components/chat/WatchingBanner.tsx
@@ -1,0 +1,28 @@
+interface WatchingBannerProps {
+  /** Open the take-over flow (fork this CLI session into an SDK-driven branch). */
+  onTakeover: () => void
+}
+
+/**
+ * Shown above the input when the panel is OBSERVING a session running in the
+ * Claude Code CLI (read-only mirror — the CLI is the source of truth). The
+ * "Take over" button is the deliberate, single-action entry into CONTROL mode:
+ * it forks the conversation into a new SDK-owned branch while the original CLI
+ * session keeps running. One writer per lineage — we never write into the CLI's.
+ */
+export function WatchingBanner({ onTakeover }: WatchingBannerProps) {
+  return (
+    <div className="mb-2 flex items-center justify-between gap-3 rounded-lg border border-blue-200 dark:border-blue-800/50 bg-blue-50 dark:bg-blue-950/30 px-3 py-2">
+      <p className="text-xs text-blue-600/80 dark:text-blue-400/70">
+        Running in Claude Code CLI — you&apos;re watching live.
+      </p>
+      <button
+        type="button"
+        onClick={onTakeover}
+        className="flex-shrink-0 rounded-md bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 dark:focus:ring-offset-gray-900"
+      >
+        Take over
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/components/chat/__tests__/WatchingBanner.test.tsx
+++ b/apps/web/src/components/chat/__tests__/WatchingBanner.test.tsx
@@ -1,0 +1,18 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { WatchingBanner } from '../WatchingBanner'
+
+describe('WatchingBanner', () => {
+  it('renders the watching copy and a Take over button', () => {
+    render(<WatchingBanner onTakeover={vi.fn()} />)
+    expect(screen.getByText(/watching live/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /take over/i })).toBeInTheDocument()
+  })
+
+  it('calls onTakeover when the button is clicked', () => {
+    const onTakeover = vi.fn()
+    render(<WatchingBanner onTakeover={onTakeover} />)
+    fireEvent.click(screen.getByRole('button', { name: /take over/i }))
+    expect(onTakeover).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/lib/chat-panel/integration.test.ts
+++ b/apps/web/src/lib/chat-panel/integration.test.ts
@@ -223,6 +223,53 @@ describe('integration: takeover flow (fork)', () => {
     expect(allCmds).toContainEqual(expect.objectContaining({ cmd: 'CLOSE_TERMINAL_WS' }))
     expect(allCmds).toContainEqual(expect.objectContaining({ cmd: 'POST_FORK', sessionId: 'abc' }))
   })
+
+  test('fork fails → recovering + error toast (decision surfaced, never silently lost)', () => {
+    const watchingStore: ChatPanelStore = {
+      panel: { phase: 'cc_cli', sessionId: 'abc', blocks: [], sub: { sub: 'watching' } },
+      outbox: { messages: [] },
+      meta: null,
+      projectPath: null,
+      lastModel: null,
+      lastPermissionMode: null,
+      historyPagination: null,
+    }
+
+    const { store, allCmds } = drive(watchingStore, [
+      { type: 'TAKEOVER_CLI' },
+      { type: 'ACQUIRE_FAILED', error: 'Fork failed: session file not found' },
+    ])
+
+    expect(store.panel.phase).toBe('recovering')
+    expect(allCmds).toContainEqual(expect.objectContaining({ cmd: 'TOAST', variant: 'error' }))
+  })
+
+  test('fork fails → original CLI stays observable: recovering → OWNERSHIP_CHANGED(watchable) → cc_cli watching', () => {
+    const watchingStore: ChatPanelStore = {
+      panel: { phase: 'cc_cli', sessionId: 'abc', blocks: [], sub: { sub: 'watching' } },
+      outbox: { messages: [] },
+      meta: null,
+      projectPath: null,
+      lastModel: null,
+      lastPermissionMode: null,
+      historyPagination: null,
+    }
+
+    const { store, allCmds } = drive(watchingStore, [
+      { type: 'TAKEOVER_CLI' },
+      { type: 'ACQUIRE_FAILED', error: 'boom' },
+      // The original CLI session is still live → SSE re-asserts watchable ownership.
+      { type: 'OWNERSHIP_CHANGED', tier: { tmux: { cliSessionId: 'cv-1' } } },
+    ])
+
+    expect(store.panel.phase).toBe('cc_cli')
+    if (store.panel.phase === 'cc_cli') {
+      expect(store.panel.sub.sub).toBe('watching')
+    }
+    expect(allCmds).toContainEqual(
+      expect.objectContaining({ cmd: 'OPEN_TERMINAL_WS', sessionId: 'abc' }),
+    )
+  })
 })
 
 // ── Error recovery ────────────────────────────────────────────────

--- a/apps/web/src/pages/ChatSession.tsx
+++ b/apps/web/src/pages/ChatSession.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ChatInputBar } from '../components/chat/ChatInputBar'
 import { McpPanel } from '../components/chat/McpPanel'
 import { ModelSelector } from '../components/chat/ModelSelector'
-import { TakeoverDialog } from '../components/chat/TakeoverDialog'
+import { TakeoverConfirmDialog } from '../components/chat/TakeoverConfirmDialog'
+import { WatchingBanner } from '../components/chat/WatchingBanner'
 import { ErrorBoundary } from '@claude-view/shared/components/ErrorBoundary'
 import { ConversationThread } from '@claude-view/shared/components/conversation/ConversationThread'
 import { ThinkingIndicator } from '@claude-view/shared/components/conversation/ThinkingIndicator'
@@ -277,6 +278,22 @@ export function ChatSession({
   // Takeover dialog state
   const [showTakeover, setShowTakeover] = useState(false)
 
+  // Enter CONTROL mode: fork the watched CLI session into an SDK branch.
+  // Skip the confirm dialog if the user previously opted out ("don't remind me").
+  const handleTakeover = useCallback(() => {
+    let skipConfirm = false
+    try {
+      skipConfirm = localStorage.getItem('claude-view:takeover-no-remind') === 'true'
+    } catch {
+      /* localStorage unavailable — fall through to the confirm dialog */
+    }
+    if (skipConfirm) {
+      dispatch({ type: 'TAKEOVER_CLI' })
+    } else {
+      setShowTakeover(true)
+    }
+  }, [dispatch])
+
   return (
     <div className="flex-1 min-w-0 flex flex-col overflow-hidden" data-panel-mode={viewMode}>
       {/* Header */}
@@ -423,14 +440,7 @@ export function ChatSession({
       {/* Input */}
       <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-800">
         <div className="max-w-3xl mx-auto px-4 py-3">
-          {/* TODO: re-enable fork banner when fork flow is fixed */}
-          {viewMode === 'watching' && (
-            <div className="mb-2 rounded-lg border border-blue-200 dark:border-blue-800/50 bg-blue-50 dark:bg-blue-950/30 px-3 py-2">
-              <p className="text-xs text-blue-600/80 dark:text-blue-400/70">
-                This session is running in Claude Code CLI.
-              </p>
-            </div>
-          )}
+          {viewMode === 'watching' && <WatchingBanner onTakeover={handleTakeover} />}
           <ChatInputBar
             onSend={handleSend}
             onStop={() => dispatch({ type: 'INTERRUPT' })}
@@ -489,7 +499,7 @@ export function ChatSession({
         </div>
       </div>
 
-      <TakeoverDialog
+      <TakeoverConfirmDialog
         open={showTakeover}
         onConfirm={() => {
           setShowTakeover(false)


### PR DESCRIPTION
## Control v2 — Pillar 1 (take-over by fork)

Watch a session running in the Claude Code CLI, click **Take over**, and continue it in the browser. It **forks** the conversation into a new SDK-owned branch — the original CLI session keeps running and stays in the sidebar. One writer per lineage: we fork, never write into the CLI's session.

**Why it was off.** The fork FSM (`cc_cli → TAKEOVER_CLI → POST_FORK → … → sdk_owned`) and the sidecar `/fork` route were already built and green; the entry point was disabled *precautionarily* (`ChatSession.tsx:426`) before a real backend bug — which was fixed the next day in `8f52cd8d` (`forkControlSession` missing the `resolveExistingSession` pre-flight). This PR just re-wires the entry + fork navigation.

**Changes:**
- new **`WatchingBanner`** — the single deliberate "Take over" entry into CONTROL mode (replaces the dead passive banner).
- **`ChatSession`** — `handleTakeover` (skips the confirm dialog when "don't remind me" is set, else opens `TakeoverConfirmDialog` → `TAKEOVER_CLI`); swapped the unused `TakeoverDialog` for the richer no-remind `TakeoverConfirmDialog`.
- **`ChatPanel`** — ungate `onSessionCreated` so a fork's new session id updates the dockview panel + router URL (it was gated to the blank-panel create flow). No new `NAVIGATE` command — reuses the proven create-flow nav path.

**Failure safety (already wired; now tested):** a failed fork routes to `recovering` + an error toast and falls back to `cc_cli` watching on the next ownership event — so a failed fork never strands the user or loses the original.

**Follow-up:** the sidebar dropdown "Take over" stays disabled — its handler still does `resume` (kill+resume, the racy path fork replaces); re-pointing it at fork is a separate change.

**Verification:** +2 integration tests (fork-fail → recovering+toast; fork-fail → back to watching) + `WatchingBanner` unit test; web typecheck + full pre-push gate green. ⚠️ Live-UI click-through (real CLI session) recommended as manual QA — not exercised headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)