### PR TITLE
fix(pricing): family-nearest fallback so new models never show "Unavailable"

### DIFF
--- a/apps/web/src/components/live/CostTooltip.tsx
+++ b/apps/web/src/components/live/CostTooltip.tsx
@@ -261,7 +261,7 @@ export function CostTooltip({
  * `data/README.md`. When bumping `last_verified` in `data/anthropic-pricing.json`,
  * update this constant in the same commit.
  */
-const PRICING_LAST_VERIFIED = '2026-04-14'
+const PRICING_LAST_VERIFIED = '2026-06-02'
 
 function CostRow({
   label,

--- a/crates/core/src/pricing/audit.rs
+++ b/crates/core/src/pricing/audit.rs
@@ -9,16 +9,20 @@ use std::path::Path;
 
 use crate::session_stats::extract_stats;
 
-use super::lookup::lookup_pricing;
+use super::lookup::{resolve_pricing, MatchKind};
 use super::types::PricingTable;
 
-/// Scan a set of JSONL files for distinct model IDs, return those not in pricing.
+/// Scan a set of JSONL files for distinct model IDs that lack an *exact* price.
 ///
 /// Caller picks which paths to audit — typical use is the N most recent sessions
 /// from `SessionCatalog`. Best-effort: files that fail to parse are skipped
 /// silently rather than aborting the scan.
 ///
-/// Returns a sorted, deduplicated list of unpriced model IDs.
+/// Returns a sorted, deduplicated list of model IDs that are NOT exactly priced —
+/// i.e. either served by the family-nearest fallback (cost is estimated from a
+/// sibling release; a precise `data/anthropic-pricing.json` entry should be added)
+/// or entirely unknown. Exact / alias / prefix matches are considered fully priced
+/// and are not reported.
 pub fn scan_unpriced_models(paths: &[(&Path, bool)], pricing: &PricingTable) -> Vec<String> {
     let mut seen: HashSet<String> = HashSet::new();
     let mut unpriced: Vec<String> = Vec::new();
@@ -31,7 +35,11 @@ pub fn scan_unpriced_models(paths: &[(&Path, bool)], pricing: &PricingTable) -> 
             if !seen.insert(model_id.clone()) {
                 continue;
             }
-            if lookup_pricing(model_id, pricing).is_none() {
+            let needs_exact_entry = match resolve_pricing(model_id, pricing) {
+                None => true,
+                Some(m) => m.kind == MatchKind::FamilyFallback,
+            };
+            if needs_exact_entry {
                 unpriced.push(model_id.clone());
             }
         }

--- a/crates/core/src/pricing/loader.rs
+++ b/crates/core/src/pricing/loader.rs
@@ -96,8 +96,8 @@ mod tests {
     #[test]
     fn test_load_pricing_parses_all_models() {
         let pricing = load_pricing();
-        // 16 models + 3 aliases = 19 entries
-        assert_eq!(pricing.len(), 19);
+        // 17 models + 3 aliases = 20 entries
+        assert_eq!(pricing.len(), 20);
     }
 
     /// Models known to appear in real JSONL sessions right now.
@@ -107,6 +107,7 @@ mod tests {
     /// list is the CI gate: if a dev forgets the pricing update, the test below
     /// fails with a pointer to the fix.
     const ACTIVE_MODELS: &[&str] = &[
+        "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-opus-4-6",
         "claude-sonnet-4-6",
@@ -126,6 +127,33 @@ mod tests {
                 model_id
             );
         }
+    }
+
+    #[test]
+    fn test_opus_48_priced_and_matches_opus_47() {
+        // Verified against platform.claude.com/docs/.../pricing on 2026-06-02:
+        // Opus 4.8 is $5 in / $25 out / $6.25 5m-cache / $10 1h-cache / $0.50 read,
+        // identical to Opus 4.7. The family fallback would produce the same value,
+        // but an exact entry keeps the displayed cost precise (no estimate).
+        let pricing = load_pricing();
+        let opus48 = pricing.get("claude-opus-4-8").expect(
+            "Opus 4.8 must be in pricing table — JSONL files already contain this model ID",
+        );
+        let opus47 = pricing.get("claude-opus-4-7").unwrap();
+        assert_eq!(opus48.input_cost_per_token, opus47.input_cost_per_token);
+        assert_eq!(opus48.output_cost_per_token, opus47.output_cost_per_token);
+        assert_eq!(
+            opus48.cache_creation_cost_per_token,
+            opus47.cache_creation_cost_per_token
+        );
+        assert_eq!(
+            opus48.cache_read_cost_per_token,
+            opus47.cache_read_cost_per_token
+        );
+        assert_eq!(
+            opus48.cache_creation_cost_per_token_1hr,
+            opus47.cache_creation_cost_per_token_1hr
+        );
     }
 
     #[test]

--- a/crates/core/src/pricing/lookup.rs
+++ b/crates/core/src/pricing/lookup.rs
@@ -17,34 +17,179 @@ pub fn resolve_model_alias(alias: &str) -> Option<&'static str> {
     }
 }
 
+/// Claude model family — the pricing-relevant grouping.
+///
+/// Pricing has historically been stable *within* a family across point releases
+/// (Opus 4.5/4.6/4.7/4.8 are all $5/$25), which is what makes family-nearest
+/// fallback safe for a brand-new release whose exact rate isn't in the table yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Family {
+    Opus,
+    Sonnet,
+    Haiku,
+}
+
+impl Family {
+    fn from_token(token: &str) -> Option<Self> {
+        match token {
+            "opus" => Some(Family::Opus),
+            "sonnet" => Some(Family::Sonnet),
+            "haiku" => Some(Family::Haiku),
+            _ => None,
+        }
+    }
+}
+
+/// How a model id was matched to a pricing entry. Lets the drift audit distinguish
+/// "exactly priced" from "served by the family fallback" (i.e. add a precise entry).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchKind {
+    /// Direct key in the pricing table.
+    Exact,
+    /// Resolved through a short alias ("opus"/"sonnet"/"haiku").
+    Alias,
+    /// Prefix relationship with a table key (e.g. a dated variant of a base id).
+    Prefix,
+    /// Inherited from the nearest-version sibling in the same model family.
+    FamilyFallback,
+}
+
+/// A resolved pricing entry plus how it was matched.
+pub struct PricingMatch<'a> {
+    pub pricing: &'a ModelPricing,
+    pub kind: MatchKind,
+}
+
+/// Parse a Claude model id into `(family, (major, minor))` for cross-release fallback.
+///
+/// Handles both id orderings:
+/// - new: `claude-opus-4-8`        → (Opus, (4, 8))
+/// - new dated: `claude-opus-4-5-20251101` → (Opus, (4, 5))  (date suffix ignored)
+/// - legacy: `claude-3-5-sonnet-20241022`  → (Sonnet, (3, 5))
+/// - legacy: `claude-3-opus-20240229`      → (Opus, (3, 0))
+///
+/// Returns `None` for non-Claude or family-less ids (e.g. `gpt-4o`, `unknown-model`),
+/// which preserves the project's "never fabricate a rate for a foreign model" rule.
+fn parse_claude_model(model_id: &str) -> Option<(Family, (u32, u32))> {
+    let lower = model_id.to_ascii_lowercase();
+    if !lower.starts_with("claude") {
+        return None;
+    }
+    let mut family: Option<Family> = None;
+    let mut versions: Vec<u32> = Vec::new();
+    for token in lower.split('-') {
+        if let Some(f) = Family::from_token(token) {
+            family = Some(f);
+        } else if let Ok(n) = token.parse::<u32>() {
+            // Version components are small; 8-digit date suffixes (e.g. 20251101)
+            // and other large numbers are not version numbers.
+            if n < 1000 {
+                versions.push(n);
+            }
+        }
+    }
+    let family = family?;
+    let major = versions.first().copied().unwrap_or(0);
+    let minor = versions.get(1).copied().unwrap_or(0);
+    Some((family, (major, minor)))
+}
+
+/// Find the nearest-version pricing entry in the same family as `model_id`.
+///
+/// Prefers the highest known version `<=` the requested version (the most recent
+/// *preceding* release — a point release inherits the current rate). If the
+/// requested model predates everything known, falls back to the lowest known
+/// version in the family. Returns `None` when the family can't be identified or
+/// has no priced members.
+fn family_nearest_pricing<'a>(
+    model_id: &str,
+    pricing: &'a HashMap<String, ModelPricing>,
+) -> Option<&'a ModelPricing> {
+    let (want_family, want_version) = parse_claude_model(model_id)?;
+
+    // Same-family table entries with a real version. Bare aliases ("opus") don't
+    // start with "claude" so they parse to `None` and are naturally excluded.
+    let mut candidates: Vec<((u32, u32), &ModelPricing)> = pricing
+        .iter()
+        .filter_map(|(key, p)| {
+            let (family, version) = parse_claude_model(key)?;
+            (family == want_family && version != (0, 0)).then_some((version, p))
+        })
+        .collect();
+    if candidates.is_empty() {
+        return None;
+    }
+    candidates.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // Highest version <= requested (nearest preceding), else lowest known.
+    candidates
+        .iter()
+        .rev()
+        .find(|(version, _)| *version <= want_version)
+        .or_else(|| candidates.first())
+        .map(|(_, p)| *p)
+}
+
+/// Resolve pricing for a model id, reporting how it was matched.
+///
+/// Resolution order: exact → alias → prefix (either direction) → family-nearest
+/// fallback. The family fallback is what keeps a brand-new point release (e.g.
+/// `claude-opus-4-8` before its exact row is added) from showing "Unavailable":
+/// it inherits the newest same-family rate. Only genuinely foreign ids (no Claude
+/// family) return `None`.
+pub fn resolve_pricing<'a>(
+    model_id: &str,
+    pricing: &'a HashMap<String, ModelPricing>,
+) -> Option<PricingMatch<'a>> {
+    if let Some(p) = pricing.get(model_id) {
+        return Some(PricingMatch {
+            pricing: p,
+            kind: MatchKind::Exact,
+        });
+    }
+    if let Some(resolved) = resolve_model_alias(model_id) {
+        if let Some(p) = pricing.get(resolved) {
+            return Some(PricingMatch {
+                pricing: p,
+                kind: MatchKind::Alias,
+            });
+        }
+    }
+    // Prefix matching: a table key is a prefix of model_id (dated variant of a base id).
+    for (key, p) in pricing {
+        if model_id.starts_with(key.as_str()) {
+            return Some(PricingMatch {
+                pricing: p,
+                kind: MatchKind::Prefix,
+            });
+        }
+    }
+    // Reverse prefix: model_id is a prefix of a table key.
+    for (key, p) in pricing {
+        if key.starts_with(model_id) {
+            return Some(PricingMatch {
+                pricing: p,
+                kind: MatchKind::Prefix,
+            });
+        }
+    }
+    // Family-nearest-version fallback: a brand-new point release inherits the
+    // newest known same-family rate instead of being left unpriced.
+    family_nearest_pricing(model_id, pricing).map(|p| PricingMatch {
+        pricing: p,
+        kind: MatchKind::FamilyFallback,
+    })
+}
+
 /// Look up pricing for a model ID.
 ///
-/// Resolution order: exact match → alias resolution → prefix match → reverse prefix.
+/// Thin wrapper over [`resolve_pricing`] that discards the match kind. Resolution
+/// order: exact → alias → prefix → family-nearest fallback.
 pub fn lookup_pricing<'a>(
     model_id: &str,
     pricing: &'a HashMap<String, ModelPricing>,
 ) -> Option<&'a ModelPricing> {
-    if let Some(p) = pricing.get(model_id) {
-        return Some(p);
-    }
-    if let Some(resolved) = resolve_model_alias(model_id) {
-        if let Some(p) = pricing.get(resolved) {
-            return Some(p);
-        }
-    }
-    // Prefix matching: key is prefix of model_id
-    for (key, p) in pricing {
-        if model_id.starts_with(key.as_str()) {
-            return Some(p);
-        }
-    }
-    // Reverse prefix: model_id is prefix of key
-    for (key, p) in pricing {
-        if key.starts_with(model_id) {
-            return Some(p);
-        }
-    }
-    None
+    resolve_pricing(model_id, pricing).map(|m| m.pricing)
 }
 
 #[cfg(test)]
@@ -86,5 +231,113 @@ mod tests {
     fn test_prefix_lookup_sonnet_46_dated() {
         let pricing = load_pricing();
         assert!(lookup_pricing("claude-sonnet-4-6-20260301", &pricing).is_some());
+    }
+
+    // ---- RED: a brand-new point release must never show "Unavailable" again ----
+
+    #[test]
+    fn test_future_point_release_resolves_via_family_fallback() {
+        let pricing = load_pricing();
+        // A model id newer than anything in the table must still resolve, inheriting
+        // the nearest known same-family rate. This is the regression guard for the
+        // recurring "cost Unavailable" bug (claude-opus-4-8 etc.).
+        let opus_future = lookup_pricing("claude-opus-4-99", &pricing)
+            .expect("future opus point release must resolve via family fallback");
+        let opus_latest = pricing.get("claude-opus-4-7").unwrap();
+        assert_eq!(
+            opus_future.input_cost_per_token, opus_latest.input_cost_per_token,
+            "future opus should inherit the newest known opus input rate"
+        );
+        assert_eq!(
+            opus_future.output_cost_per_token,
+            opus_latest.output_cost_per_token
+        );
+        assert!(lookup_pricing("claude-sonnet-9-9", &pricing).is_some());
+        assert!(lookup_pricing("claude-haiku-9-9", &pricing).is_some());
+    }
+
+    #[test]
+    fn test_parse_claude_model_both_orderings() {
+        // New ordering: family then version.
+        assert_eq!(
+            parse_claude_model("claude-opus-4-8"),
+            Some((Family::Opus, (4, 8)))
+        );
+        assert_eq!(
+            parse_claude_model("claude-sonnet-4-6"),
+            Some((Family::Sonnet, (4, 6)))
+        );
+        // New dated: trailing 8-digit date is ignored.
+        assert_eq!(
+            parse_claude_model("claude-opus-4-5-20251101"),
+            Some((Family::Opus, (4, 5)))
+        );
+        // Legacy ordering: version before family.
+        assert_eq!(
+            parse_claude_model("claude-3-5-sonnet-20241022"),
+            Some((Family::Sonnet, (3, 5)))
+        );
+        assert_eq!(
+            parse_claude_model("claude-3-opus-20240229"),
+            Some((Family::Opus, (3, 0)))
+        );
+        // Foreign / family-less ids must NOT parse (preserves "no fabricated rate").
+        assert_eq!(parse_claude_model("gpt-4o"), None);
+        assert_eq!(parse_claude_model("unknown-model"), None);
+        assert_eq!(parse_claude_model("claude-instant"), None);
+    }
+
+    #[test]
+    fn test_resolve_pricing_classifies_match_kind() {
+        let pricing = load_pricing();
+        // Exact table hit.
+        assert_eq!(
+            resolve_pricing("claude-opus-4-7", &pricing).unwrap().kind,
+            MatchKind::Exact
+        );
+        // `load_pricing()` flattens aliases into the map, so "opus" is itself an
+        // exact key — the dedicated alias branch is only reached for a table that
+        // lacks the flattened entry (covered below).
+        assert_eq!(
+            resolve_pricing("opus", &pricing).unwrap().kind,
+            MatchKind::Exact
+        );
+        // Family fallback for an unknown future version.
+        assert_eq!(
+            resolve_pricing("claude-opus-4-99", &pricing).unwrap().kind,
+            MatchKind::FamilyFallback
+        );
+        // Foreign model: no fabricated rate.
+        assert!(resolve_pricing("gpt-4o", &pricing).is_none());
+        assert!(resolve_pricing("unknown-model", &pricing).is_none());
+    }
+
+    #[test]
+    fn test_resolve_pricing_alias_branch_on_unflattened_table() {
+        // A table WITHOUT flattened aliases exercises the resolve_model_alias branch.
+        let full = load_pricing();
+        let mut table: HashMap<String, ModelPricing> = HashMap::new();
+        table.insert(
+            "claude-opus-4-6".to_string(),
+            full.get("claude-opus-4-6").unwrap().clone(),
+        );
+        let m = resolve_pricing("opus", &table).expect("alias should resolve to target");
+        assert_eq!(m.kind, MatchKind::Alias);
+    }
+
+    #[test]
+    fn test_family_fallback_picks_nearest_preceding_not_oldest() {
+        let pricing = load_pricing();
+        // opus-4-99 must inherit the NEWEST opus rate ($5/$25), never the old
+        // $15/$25 Opus 4.1/4.0 rate — otherwise cost would be 3x wrong.
+        let p = lookup_pricing("claude-opus-4-99", &pricing).unwrap();
+        assert!(
+            (p.input_cost_per_token - 5e-6).abs() < 1e-15,
+            "expected newest opus input rate $5/MTok, got {}",
+            p.input_cost_per_token * 1e6
+        );
+        // Sonnet future inherits $3/$15.
+        let s = lookup_pricing("claude-sonnet-9-9", &pricing).unwrap();
+        assert!((s.input_cost_per_token - 3e-6).abs() < 1e-15);
     }
 }

--- a/crates/core/src/pricing/mod.rs
+++ b/crates/core/src/pricing/mod.rs
@@ -14,7 +14,7 @@ pub use audit::scan_unpriced_models;
 pub use calculate::{calculate_cost, calculate_cost_usd, finalize_cost_breakdown};
 pub use extract::extract_usage_tokens;
 pub use loader::load_pricing;
-pub use lookup::{lookup_pricing, resolve_model_alias};
+pub use lookup::{lookup_pricing, resolve_model_alias, resolve_pricing, Family, MatchKind};
 pub use types::{
     CacheStatus, CostBreakdown, ModelPricing, PricingTable, TokenBreakdown, TokenUsage,
 };
@@ -38,4 +38,11 @@ pub use types::{
 ///   nested `cache_creation.ephemeral_{5m,1h}_input_tokens`. Pre-v2 turns
 ///   with 1-hour cache usage were under-priced ~37.5% (5m rate applied to
 ///   1h tokens).
-pub const PRICING_VERSION: u32 = 2;
+/// - **v3**: 2026-06-02 — `lookup_pricing` gained a family-nearest-version
+///   fallback (`lookup::family_nearest_pricing`): a brand-new point release
+///   (e.g. `claude-opus-4-8`) now inherits the newest known same-family rate
+///   instead of being left unpriced. Added the exact `claude-opus-4-8` row.
+///   Pre-v3, sessions whose model post-dated the pricing table were stored with
+///   NULL/zero `total_cost_usd` (UI showed "Unavailable"); reindex recomputes
+///   them with real costs.
+pub const PRICING_VERSION: u32 = 3;

--- a/data/anthropic-pricing.json
+++ b/data/anthropic-pricing.json
@@ -1,8 +1,20 @@
 {
   "source": "https://docs.anthropic.com/en/docs/about-claude/pricing",
-  "last_verified": "2026-04-17",
+  "last_verified": "2026-06-02",
   "unit": "usd_per_million_tokens",
   "models": {
+    "claude-opus-4-8": {
+      "display_name": "Claude Opus 4.8",
+      "input": 5.0,
+      "output": 25.0,
+      "cache_write_5m": 6.25,
+      "cache_write_1hr": 10.0,
+      "cache_read": 0.5,
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "long_context_pricing": null,
+      "tokenizer_note": "Opus 4.7 and later use a new tokenizer and may use up to 35% more tokens for the same text vs earlier models."
+    },
     "claude-opus-4-7": {
       "display_name": "Claude Opus 4.7",
       "input": 5.0,


### PR DESCRIPTION
## Problem

Session cost shows **"Unavailable"** whenever a brand-new Claude model lands in JSONL before the pricing table knows it. Right now `claude-opus-4-8` (7,546 messages in real local sessions) is unpriced, so the cost reads "Unavailable" again — the same break that happened at 4.6→4.7. Every point release has required a manual `data/anthropic-pricing.json` + `ACTIVE_MODELS` patch, and the CI gate only fires for models hand-added to that list (4-8 was never added → silent miss).

## Root cause

`lookup_pricing` resolved a model id via **exact → alias → prefix** only. A new point release like `claude-opus-4-8` is a prefix of no table key and has no key as its prefix, so all branches miss → `calculate_cost` takes its unpriced branch (`total_usd=0`, `has_unpriced_usage=true`) → the UI gate `hasUnavailableCost` renders "Unavailable". `lookup_pricing` is the single chokepoint every cost path funnels through, so the fix lives there.

## Fix (resolver-level, one chokepoint)

- **Family-nearest-version fallback.** Parse the model id into `(family, (major, minor))` — handling both `claude-opus-4-8` and legacy `claude-3-5-sonnet-…` orderings — and inherit the newest known same-family rate (`opus-4-8 → opus-4-7 = $5/$25`). Verified against official pricing (2026-06-02): Opus 4.8 == 4.7 rates, so the inherited price is **exact, not a guess**. Foreign ids (`gpt-4o`, `unknown-model`) still return `None` → still "Unavailable", preserving "never fabricate a rate for a non-Claude model".
- **`MatchKind` {Exact, Alias, Prefix, FamilyFallback}.** The startup drift scan now flags `FamilyFallback` (not just fully-unpriced), so a maintainer is still nudged to add a precise entry.
- **Exact `claude-opus-4-8` row + `ACTIVE_MODELS` entry** for precision today.
- **`PRICING_VERSION` 2→3** → fingerprint mismatch → `mark_all_sessions_for_reindex()` on next startup, so stored `total_cost_usd` aggregates recompute.
- Align `CostTooltip` `PRICING_LAST_VERIFIED` with `last_verified` (was drifted).

## Verification

- **39/39 pricing unit tests**, incl. a RED→GREEN regression (`test_future_point_release_resolves_via_family_fallback`) guaranteeing future point releases resolve with no code patch, and nearest-preceding selection (`opus-4-99 → $5`, not the old `$15` Opus 4.1 rate).
- **Real-data e2e**: a real Opus 4.8 session through the production path (`extract_stats → calculate_cost`) → **\$1.58, priced, 100% coverage** (previously "Unavailable").
- Cost regression: core/db/server cost suites + **84/84** frontend cost-UI tests.
- `clippy -D warnings` clean; full local pre-push CI (cargo-deny + clippy + rust-test) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)