### PR TITLE
feat(interact): trustworthy interaction UI — no silent auto-deny + surface failed delivery (Control v2 PR-2)

### DIFF
--- a/packages/shared/src/components/conversation/blocks/shared/PermissionCard.tsx
+++ b/packages/shared/src/components/conversation/blocks/shared/PermissionCard.tsx
@@ -1,8 +1,13 @@
 import type { PermissionRequest } from '../../../../types/sidecar-protocol'
 import { ShieldAlert } from 'lucide-react'
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { cn } from '../../../../utils/cn'
+import { useCallback, useEffect, useState } from 'react'
 import { InteractiveCardShell } from './InteractiveCardShell'
+
+/** Human-friendly "time waiting for your decision" label. */
+function formatWaiting(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`
+}
 
 function getToolDisplay(
   toolName: string,
@@ -39,57 +44,45 @@ export function PermissionCard({
   onAlwaysAllow,
   resolved,
 }: PermissionCardProps) {
-  const totalSeconds = Math.ceil(permission.timeoutMs / 1000)
-  const [countdown, setCountdown] = useState(totalSeconds)
-  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
-  const onRespondRef = useRef(onRespond)
-  onRespondRef.current = onRespond
-  const toolNameRef = useRef(permission.toolName)
-  toolNameRef.current = permission.toolName
-
   const requestId = permission.requestId
-  const timeoutMs = permission.timeoutMs
+  const interactive = !!onRespond
 
-  const autoDeniedRef = useRef(false)
-
+  // Trust-over-accuracy: a permission prompt NEVER auto-resolves. We show how
+  // long it has been awaiting your decision (an attention cue), pausing the
+  // counter while the tab is hidden so it reflects actual attention — but the
+  // prompt stays pending until you decide. 寧願唔顯示，都唔顯示錯嘅嘢.
+  const [waiting, setWaiting] = useState(0)
   useEffect(() => {
-    if (resolved || !onRespondRef.current) return
-    autoDeniedRef.current = false
-
-    const secs = Math.ceil(timeoutMs / 1000)
-    setCountdown(secs)
-
-    timerRef.current = setInterval(() => {
-      setCountdown((prev) => (prev <= 1 ? 0 : prev - 1))
-    }, 1000)
-
+    if (resolved || !interactive) return
+    setWaiting(0)
+    let id: ReturnType<typeof setInterval> | null = null
+    const start = () => {
+      if (id == null) id = setInterval(() => setWaiting((w) => w + 1), 1000)
+    }
+    const stop = () => {
+      if (id != null) {
+        clearInterval(id)
+        id = null
+      }
+    }
+    const onVisibility = () => (document.visibilityState === 'hidden' ? stop() : start())
+    if (document.visibilityState !== 'hidden') start()
+    document.addEventListener('visibilitychange', onVisibility)
     return () => {
-      if (timerRef.current) clearInterval(timerRef.current)
+      stop()
+      document.removeEventListener('visibilitychange', onVisibility)
     }
-  }, [requestId, timeoutMs, resolved])
-
-  // Auto-deny side effect — runs outside the setState updater to avoid
-  // "Cannot update component X while rendering component Y" React warning.
-  useEffect(() => {
-    if (countdown === 0 && !resolved && !autoDeniedRef.current) {
-      autoDeniedRef.current = true
-      if (timerRef.current) clearInterval(timerRef.current)
-      onRespondRef.current?.(requestId, false)
-    }
-  }, [countdown, resolved, requestId])
+  }, [requestId, resolved, interactive])
 
   const handleAllow = useCallback(() => {
-    if (timerRef.current) clearInterval(timerRef.current)
     onRespond?.(requestId, true)
   }, [onRespond, requestId])
 
   const handleDeny = useCallback(() => {
-    if (timerRef.current) clearInterval(timerRef.current)
     onRespond?.(requestId, false)
   }, [onRespond, requestId])
 
   const handleAlwaysAllow = useCallback(() => {
-    if (timerRef.current) clearInterval(timerRef.current)
     if (permission.suggestions && onAlwaysAllow) {
       onAlwaysAllow(requestId, true, permission.suggestions)
     }
@@ -179,26 +172,11 @@ export function PermissionCard({
           </div>
         )}
 
-        {!resolved && (
-          <div className="flex items-center gap-2">
-            <div className="flex-1 h-1 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
-              <div
-                className={cn(
-                  'h-full rounded-full transition-all duration-1000 ease-linear',
-                  countdown < 10 ? 'bg-red-500 animate-pulse' : 'bg-amber-500',
-                )}
-                style={{ width: `${(countdown / totalSeconds) * 100}%` }}
-              />
-            </div>
-            <span
-              className={cn(
-                'text-xs font-mono tabular-nums w-6 text-right',
-                countdown < 10
-                  ? 'text-red-500 dark:text-red-400 font-bold'
-                  : 'text-gray-500 dark:text-gray-400',
-              )}
-            >
-              {countdown}s
+        {!resolved && interactive && (
+          <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400">
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-amber-500 animate-pulse" />
+            <span className="tabular-nums">
+              Waiting for your response{waiting > 0 ? ` · ${formatWaiting(waiting)}` : ''}
             </span>
           </div>
         )}

--- a/packages/shared/src/components/conversation/blocks/shared/SessionInteractionCard.tsx
+++ b/packages/shared/src/components/conversation/blocks/shared/SessionInteractionCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import {
   normalizePermissionRequest,
   normalizeAskQuestion,
@@ -80,89 +80,126 @@ function FullCard({
 }) {
   const { variant, data } = fullInteraction
 
-  // ── Permission ────────────────────────────────────────────
-  const handlePermissionRespond = useCallback(
-    (requestId: string, allowed: boolean) => {
-      respond?.({ variant: 'permission', requestId, allowed })
+  // Trust-over-accuracy: await the delivery ack. The card does NOT optimistically
+  // resolve — the server clears the pending interaction (and unmounts this card)
+  // via SSE only once the agent actually consumed the decision. If delivery is
+  // not confirmed (4xx/5xx/offline), keep the card and surface a retry hint so a
+  // failed send is never shown as success. 寧願唔顯示，都唔顯示錯嘅嘢.
+  const [deliveryError, setDeliveryError] = useState<string | null>(null)
+
+  const runRespond = useCallback(
+    async (request: InteractRequest) => {
+      if (!respond) return
+      setDeliveryError(null)
+      const result = await respond(request)
+      if (!result.ok) {
+        const detail =
+          result.status === 0 ? 'no connection' : `the agent didn't confirm (${result.status})`
+        setDeliveryError(`Couldn't deliver your response — ${detail}. Tap again to retry.`)
+      }
     },
     [respond],
   )
 
+  // ── Permission ────────────────────────────────────────────
+  const handlePermissionRespond = useCallback(
+    (requestId: string, allowed: boolean) => {
+      void runRespond({ variant: 'permission', requestId, allowed })
+    },
+    [runRespond],
+  )
+
   const handlePermissionAlwaysAllow = useCallback(
     (requestId: string, allowed: boolean, updatedPermissions: unknown[]) => {
-      respond?.({ variant: 'permission', requestId, allowed, updatedPermissions })
+      void runRespond({ variant: 'permission', requestId, allowed, updatedPermissions })
     },
-    [respond],
+    [runRespond],
   )
 
   // ── Question ──────────────────────────────────────────────
   const handleQuestionAnswer = useCallback(
     (requestId: string, answers: Record<string, string>) => {
-      respond?.({ variant: 'question', requestId, answers })
+      void runRespond({ variant: 'question', requestId, answers })
     },
-    [respond],
+    [runRespond],
   )
 
   // ── Plan ──────────────────────────────────────────────────
   const handlePlanApprove = useCallback(
     (requestId: string, approved: boolean, feedback?: string, bypassPermissions?: boolean) => {
-      respond?.({ variant: 'plan', requestId, approved, feedback, bypassPermissions })
+      void runRespond({ variant: 'plan', requestId, approved, feedback, bypassPermissions })
     },
-    [respond],
+    [runRespond],
   )
 
   // ── Elicitation ───────────────────────────────────────────
   const handleElicitationSubmit = useCallback(
     (requestId: string, response: string) => {
-      respond?.({ variant: 'elicitation', requestId, response })
+      void runRespond({ variant: 'elicitation', requestId, response })
     },
-    [respond],
+    [runRespond],
   )
 
-  switch (variant) {
-    case 'permission': {
-      const permission = normalizePermissionRequest(data)
-      if (!permission) return <InteractionError variant="permission" />
-      return (
-        <PermissionCard
-          permission={permission}
-          onRespond={respond ? handlePermissionRespond : undefined}
-          onAlwaysAllow={
-            respond && permission.suggestions?.length ? handlePermissionAlwaysAllow : undefined
-          }
-        />
-      )
-    }
+  const card = (() => {
+    switch (variant) {
+      case 'permission': {
+        const permission = normalizePermissionRequest(data)
+        if (!permission) return <InteractionError variant="permission" />
+        return (
+          <PermissionCard
+            permission={permission}
+            onRespond={respond ? handlePermissionRespond : undefined}
+            onAlwaysAllow={
+              respond && permission.suggestions?.length ? handlePermissionAlwaysAllow : undefined
+            }
+          />
+        )
+      }
 
-    case 'question': {
-      const question = normalizeAskQuestion(data)
-      if (!question) return <InteractionError variant="question" />
-      return (
-        <AskUserQuestionCard
-          question={question}
-          onAnswer={respond ? handleQuestionAnswer : undefined}
-        />
-      )
-    }
+      case 'question': {
+        const question = normalizeAskQuestion(data)
+        if (!question) return <InteractionError variant="question" />
+        return (
+          <AskUserQuestionCard
+            question={question}
+            onAnswer={respond ? handleQuestionAnswer : undefined}
+          />
+        )
+      }
 
-    case 'plan': {
-      const plan = normalizePlanApproval(data)
-      if (!plan) return <InteractionError variant="plan" />
-      return <PlanApprovalCard plan={plan} onApprove={respond ? handlePlanApprove : undefined} />
-    }
+      case 'plan': {
+        const plan = normalizePlanApproval(data)
+        if (!plan) return <InteractionError variant="plan" />
+        return <PlanApprovalCard plan={plan} onApprove={respond ? handlePlanApprove : undefined} />
+      }
 
-    case 'elicitation': {
-      const elicitation = normalizeElicitation(data)
-      if (!elicitation) return <InteractionError variant="elicitation" />
-      return (
-        <ElicitationCard
-          elicitation={elicitation}
-          onSubmit={respond ? handleElicitationSubmit : undefined}
-        />
-      )
-    }
+      case 'elicitation': {
+        const elicitation = normalizeElicitation(data)
+        if (!elicitation) return <InteractionError variant="elicitation" />
+        return (
+          <ElicitationCard
+            elicitation={elicitation}
+            onSubmit={respond ? handleElicitationSubmit : undefined}
+          />
+        )
+      }
 
-    default:
-      return <InteractionError variant={variant} />
-  }
+      default:
+        return <InteractionError variant={variant} />
+    }
+  })()
+
+  if (!deliveryError) return card
+
+  return (
+    <div>
+      <div
+        role="alert"
+        className="mb-1.5 flex items-center gap-2 rounded-md border border-red-200 dark:border-red-800/40 bg-red-50 dark:bg-red-900/20 px-2.5 py-1.5 text-xs text-red-700 dark:text-red-400"
+      >
+        {deliveryError}
+      </div>
+      {card}
+    </div>
+  )
 }

--- a/packages/shared/src/components/conversation/blocks/shared/__tests__/SessionInteractionCard.test.tsx
+++ b/packages/shared/src/components/conversation/blocks/shared/__tests__/SessionInteractionCard.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { act, render, screen, fireEvent } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { SessionInteractionCard } from '../SessionInteractionCard'
 import { CompactInteractionPreview } from '../CompactInteractionPreview'
 import { InteractionError } from '../InteractionError'
@@ -9,9 +9,7 @@ import type { PendingInteractionMeta, FullInteractionBlock } from '../SessionInt
 // Factories
 // ---------------------------------------------------------------------------
 
-function makeMeta(
-  overrides: Partial<PendingInteractionMeta> = {},
-): PendingInteractionMeta {
+function makeMeta(overrides: Partial<PendingInteractionMeta> = {}): PendingInteractionMeta {
   return {
     variant: 'permission',
     requestId: 'req-1',
@@ -20,9 +18,7 @@ function makeMeta(
   }
 }
 
-function makeFullPermission(
-  overrides: Partial<FullInteractionBlock> = {},
-): FullInteractionBlock {
+function makeFullPermission(overrides: Partial<FullInteractionBlock> = {}): FullInteractionBlock {
   return {
     id: 'ib-1',
     variant: 'permission',
@@ -41,9 +37,7 @@ function makeFullPermission(
   }
 }
 
-function makeFullQuestion(
-  overrides: Partial<FullInteractionBlock> = {},
-): FullInteractionBlock {
+function makeFullQuestion(overrides: Partial<FullInteractionBlock> = {}): FullInteractionBlock {
   return {
     id: 'ib-2',
     variant: 'question',
@@ -69,9 +63,7 @@ function makeFullQuestion(
   }
 }
 
-function makeFullPlan(
-  overrides: Partial<FullInteractionBlock> = {},
-): FullInteractionBlock {
+function makeFullPlan(overrides: Partial<FullInteractionBlock> = {}): FullInteractionBlock {
   return {
     id: 'ib-3',
     variant: 'plan',
@@ -87,9 +79,7 @@ function makeFullPlan(
   }
 }
 
-function makeFullElicitation(
-  overrides: Partial<FullInteractionBlock> = {},
-): FullInteractionBlock {
+function makeFullElicitation(overrides: Partial<FullInteractionBlock> = {}): FullInteractionBlock {
   return {
     id: 'ib-4',
     variant: 'elicitation',
@@ -114,9 +104,7 @@ function makeFullElicitation(
 describe('InteractionError', () => {
   it('renders the variant name in the error message', () => {
     render(<InteractionError variant="permission" />)
-    expect(
-      screen.getByText(/could not display permission interaction/i),
-    ).toBeInTheDocument()
+    expect(screen.getByText(/could not display permission interaction/i)).toBeInTheDocument()
   })
 })
 
@@ -142,9 +130,7 @@ describe('CompactInteractionPreview', () => {
     ]
 
     for (const { variant, label } of variants) {
-      const { unmount } = render(
-        <CompactInteractionPreview meta={makeMeta({ variant })} />,
-      )
+      const { unmount } = render(<CompactInteractionPreview meta={makeMeta({ variant })} />)
       expect(screen.getByText(label)).toBeInTheDocument()
       unmount()
     }
@@ -164,13 +150,7 @@ describe('CompactInteractionPreview', () => {
 describe('SessionInteractionCard', () => {
   it('renders CompactInteractionPreview when fullInteraction is null', () => {
     const meta = makeMeta({ preview: 'Loading preview...' })
-    render(
-      <SessionInteractionCard
-        sessionId="s-1"
-        meta={meta}
-        fullInteraction={null}
-      />,
-    )
+    render(<SessionInteractionCard sessionId="s-1" meta={meta} fullInteraction={null} />)
 
     // Should show the compact preview, not a card
     expect(screen.getByText('Permission')).toBeInTheDocument()
@@ -201,17 +181,9 @@ describe('SessionInteractionCard', () => {
       data: { broken: true } as any, // missing requestId and toolName
     })
 
-    render(
-      <SessionInteractionCard
-        sessionId="s-1"
-        meta={makeMeta()}
-        fullInteraction={invalid}
-      />,
-    )
+    render(<SessionInteractionCard sessionId="s-1" meta={makeMeta()} fullInteraction={invalid} />)
 
-    expect(
-      screen.getByText(/could not display permission interaction/i),
-    ).toBeInTheDocument()
+    expect(screen.getByText(/could not display permission interaction/i)).toBeInTheDocument()
   })
 
   it('omits action buttons when respond is undefined (read-only)', () => {
@@ -227,12 +199,8 @@ describe('SessionInteractionCard', () => {
     // Card content renders
     expect(screen.getByText('Bash')).toBeInTheDocument()
     // But no action buttons
-    expect(
-      screen.queryByRole('button', { name: /allow/i }),
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByRole('button', { name: /deny/i }),
-    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /allow/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /deny/i })).not.toBeInTheDocument()
   })
 
   it('renders AskUserQuestionCard for question variant', () => {
@@ -300,9 +268,7 @@ describe('SessionInteractionCard', () => {
       />,
     )
 
-    expect(
-      screen.getByRole('button', { name: /always allow/i }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /always allow/i })).toBeInTheDocument()
   })
 
   it('does NOT show Always Allow when permission has no suggestions', () => {
@@ -315,8 +281,90 @@ describe('SessionInteractionCard', () => {
       />,
     )
 
-    expect(
-      screen.queryByRole('button', { name: /always allow/i }),
-    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /always allow/i })).not.toBeInTheDocument()
   })
+
+  // ── PR-2: trustworthy interaction ────────────────────────────────
+
+  it('surfaces a retry hint when delivery is NOT confirmed (never shows success on a failed send)', async () => {
+    const respond = vi.fn().mockResolvedValue({ ok: false, status: 503, reason: 'sidecar down' })
+    render(
+      <SessionInteractionCard
+        sessionId="s-1"
+        meta={makeMeta()}
+        fullInteraction={makeFullPermission()}
+        respond={respond}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /^allow$/i }))
+
+    // Failure is surfaced...
+    expect(await screen.findByText(/couldn't deliver/i)).toBeInTheDocument()
+    // ...the card is NOT optimistically resolved — it stays pending for retry.
+    expect(screen.getByText('Bash')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^allow$/i })).toBeInTheDocument()
+    expect(respond).toHaveBeenCalledWith({
+      variant: 'permission',
+      requestId: 'req-1',
+      allowed: true,
+    })
+  })
+
+  it('does NOT show a retry hint on confirmed delivery', async () => {
+    const respond = vi.fn().mockResolvedValue({ ok: true })
+    render(
+      <SessionInteractionCard
+        sessionId="s-1"
+        meta={makeMeta()}
+        fullInteraction={makeFullPermission()}
+        respond={respond}
+      />,
+    )
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^allow$/i }))
+    })
+
+    expect(screen.queryByText(/couldn't deliver/i)).not.toBeInTheDocument()
+  })
+
+  it('does NOT auto-resolve a permission when the timeout elapses (no silent deny)', () => {
+    vi.useFakeTimers()
+    const respond = vi.fn().mockResolvedValue({ ok: true })
+    try {
+      render(
+        <SessionInteractionCard
+          sessionId="s-1"
+          meta={makeMeta()}
+          fullInteraction={makeFullPermission({
+            data: {
+              type: 'permission_request',
+              requestId: 'req-1',
+              toolName: 'Bash',
+              toolInput: { command: 'echo hello' },
+              toolUseID: 'tu-1',
+              timeoutMs: 1_000,
+            },
+          })}
+          respond={respond}
+        />,
+      )
+
+      // Advance well past the old 60s auto-deny window.
+      act(() => {
+        vi.advanceTimersByTime(120_000)
+      })
+
+      // The prompt must remain pending — never silently denied.
+      expect(respond).not.toHaveBeenCalled()
+      expect(screen.getByText(/waiting for your response/i)).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
 })

--- a/packages/shared/src/hooks/useInteractionResponder.ts
+++ b/packages/shared/src/hooks/useInteractionResponder.ts
@@ -17,8 +17,10 @@ export type InteractRequest =
 
 /**
  * Returns a callback that dispatches an interaction response to the backend,
- * or `undefined` when the session cannot be interacted with (null ownership
- * or observed-only — no sdk/tmux binding).
+ * or `undefined` when the session is not SDK-controlled. Only an SDK fork can
+ * receive a decision — observed (read-only mirror) and tmux-owned-only CLI
+ * sessions render the interaction read-only (wiring-up rule: never show a
+ * control the backend can't honor). Take over a CLI session to drive it.
  */
 export function useInteractionResponder(
   sessionId: string,
@@ -42,7 +44,8 @@ export function useInteractionResponder(
     [sessionId],
   )
 
-  // Interactive only when SDK or tmux-controlled — not when observed (no bindings)
-  if (!ownership || (!ownership.sdk && !ownership.tmux)) return undefined
+  // Interactive only when SDK-controlled. tmux-owned-only / observed sessions
+  // are read-only mirrors of the CLI — interaction must go through a fork.
+  if (!ownership?.sdk) return undefined
   return respond
 }


### PR DESCRIPTION
## Control v2 — Pillar 3 (trustworthy interaction, frontend)

Frontend half of the trust pillar; pairs with **#67** (ack-before-clear backend).

- **PermissionCard** — REMOVE the 60s silent auto-deny. A prompt never auto-resolves: the countdown becomes a non-resolving "waiting for you" attention indicator that pauses while the tab is hidden. Better pending+visible than a silent deny while you read.
- **SessionInteractionCard** — `await` the delivery ack instead of discarding the promise. On a failed/unconfirmed send (4xx/5xx/offline) keep the card pending and show "Couldn't deliver — tap again to retry"; never optimistically resolve. The card clears only when the server (SSE) confirms the agent consumed it.
- **useInteractionResponder** — narrow interactivity to SDK-controlled sessions only (was `sdk || tmux`). Observed / tmux-only CLI sessions render read-only; you take over (fork) to drive them.

**Deferred:** explicit "Always Deny" — a correct deny `PermissionUpdate` needs the SDK rule format verified first (0-guess); follow-up.

**Verification:** +3 tests (failed delivery → retry hint + card persists; confirmed delivery → no hint; timeout → no silent auto-deny). 16 tests green; shared + web typecheck green; full pre-push gate green.

寧願唔顯示，都唔顯示錯嘅嘢.

🤖 Generated with [Claude Code](https://claude.com/claude-code)