### PR TITLE
fix(live-ws): stop hook-broadcast busy-loop on Closed + surface Lagged (Control v2 PR-4)

### DIFF
--- a/crates/server/src/live/session_ws/handler.rs
+++ b/crates/server/src/live/session_ws/handler.rs
@@ -238,6 +238,10 @@ async fn handle_multiplexed_ws(
             .unwrap_or(0)
     };
     let mut hook_events_seen: usize = 0;
+    // Once the session's hook broadcast closes (session ended), stop polling that
+    // select arm — otherwise `recv()` returns `Closed` immediately on every poll
+    // and busy-loops the task at 100% CPU until the client disconnects.
+    let mut hook_closed = false;
 
     // 6. Main event loop
     let mut heartbeat_interval = tokio::time::interval(Duration::from_secs(15));
@@ -344,8 +348,25 @@ async fn handle_multiplexed_ws(
             }
 
             // Hook events
-            hook_event = hook_rx.recv() => {
-                if let Ok(event) = hook_event {
+            hook_event = hook_rx.recv(), if !hook_closed => {
+                let event = match hook_event {
+                    Ok(event) => event,
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        // Receiver fell behind the 256-slot broadcast; n live hook
+                        // events were dropped for this client. Surface it (the JSONL
+                        // file remains the source of truth — a reconnect re-derives
+                        // full state from scrollback) rather than failing silently.
+                        warn!(session_id = %session_id, dropped = n, "Hook broadcast lagged");
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        // Session's hook channel closed (session ended). Disable this
+                        // arm; block/raw updates from the file watcher still flow.
+                        hook_closed = true;
+                        continue;
+                    }
+                };
+                {
                     hook_events_seen += 1;
                     if hook_events_seen <= replayed_hook_count {
                         continue;


### PR DESCRIPTION
## Control v2 — Pillar 4 (observe hardening, scoped)

The multiplexed session-WS hook arm used `if let Ok(event) = hook_event { … }`, silently discarding `Err`. When a watched session ends, its hook broadcast sender drops and `recv()` returns `Closed` on every poll → the `tokio::select!` arm fires in a tight loop, pinning the task at ~100% CPU until the client disconnects.

**Fix** — match the recv result:
- `Closed` → set `hook_closed` + guard the arm (`if !hook_closed`) so it stops being polled; block/raw updates from the file watcher keep flowing.
- `Lagged(n)` → `warn!` (observability) instead of silent loss. JSONL stays the source of truth, so a reconnect re-derives full state via scrollback.

**Deliberately NOT included** (deferred, evidence-backed): the deeper observe migration — moving the main `ChatSession` off the legacy `/terminal` WS onto this multiplexed path + reordering hook replay-before-subscribe. That's the critic-flagged regression-risk change to the live-observe path (your #1 "always see CLI updates" requirement) and needs live offline/reconnect verification, which isn't safely doable unattended. The main observe UI works on `/terminal` today.

**Verified:** `clippy -D warnings` clean; 11 session_ws tests pass; full pre-push gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)