### PR TITLE
fix(stability): stop ~10-min OOM/abort crash on user machines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ claude-view-stats-rollup-derive = { path = "crates/stats-rollup-derive" }
 #
 # dev      — fastest compile, debug iteration
 # release  — fast optimized: thin LTO, parallel codegen, unwind-safe
-# dist     — ship-quality: fat LTO, PGO-ready, panic=abort, smallest+fastest
+# dist     — ship-quality: fat LTO, PGO-ready, panic=unwind (fault-isolated)
 # test     — light optimization for faster test execution
 #
 # Daily:   ./scripts/cq build --release
@@ -192,7 +192,15 @@ inherits = "release"
 opt-level = 3          # Maximum optimization — aggressive inlining, vectorization
 lto = true             # Fat LTO: single-threaded whole-program LLVM optimization
 codegen-units = 1      # Single codegen unit: maximum cross-function optimization scope
-panic = "abort"        # No unwinding tables (~2.9MB saved), no unwinding overhead
+# panic = "unwind" (inherited from release / Rust default). DO NOT set "abort".
+# This is a long-running local server that parses arbitrary user ~/.claude data
+# and runs many background tokio tasks (indexer, git-sync, file watcher, request
+# handlers). Under "abort" a panic in ANY single task SIGABRTs the whole process
+# — and since the npx launcher relayed that exit, the user's app went "down".
+# "unwind" lets tokio isolate a panicking task (logged via the panic hook) while
+# the server keeps serving. The ~2.9MB of unwind tables is a cheap price for not
+# turning one bad session record into a full-app crash. (Root cause of the
+# "stable on the dev box, dies on user machines" instability reports.)
 strip = true           # No debug symbols in shipped binary
 # trim-paths via RUSTFLAGS in build-dist.sh (not stable in Cargo.toml yet)
 

--- a/crates/db/src/indexer_parallel/orchestrator/phase_parse.rs
+++ b/crates/db/src/indexer_parallel/orchestrator/phase_parse.rs
@@ -42,11 +42,23 @@ where
 
     let skipped = Arc::new(AtomicUsize::new(0));
 
+    // Share the read-only lookup maps across all parse tasks via `Arc`.
+    //
+    // Previously each task captured `hints.clone()` + `existing_map.clone()`,
+    // i.e. a FULL deep clone of both session-keyed maps PER FILE. With N
+    // sessions that is O(N^2) peak heap (N spawned tasks each holding its own
+    // N-entry map), and it re-fires on every ~120s periodic re-scan — enough to
+    // OOM a low-RAM machine within minutes while a high-RAM dev box shrugs it
+    // off. The closures only READ these maps (`.get`), so one shared `Arc`
+    // (an O(1) refcount bump per task) gives identical behavior at O(N) heap.
+    let hints = Arc::new(hints.clone());
+    let existing_map = Arc::new(existing_map.clone());
+
     let mut handles = Vec::with_capacity(files.len());
     for (path, project_encoded, session_id) in files {
         let sem = semaphore.clone();
-        let hints = hints.clone();
-        let existing_map = existing_map.clone();
+        let hints = Arc::clone(&hints);
+        let existing_map = Arc::clone(&existing_map);
         let skipped = skipped.clone();
         let registry = registry.clone();
         let force_reindex = force_search_reindex;

--- a/npx-cli/index.js
+++ b/npx-cli/index.js
@@ -6,6 +6,7 @@ const path = require('path')
 const os = require('os')
 const https = require('https')
 const zlib = require('zlib')
+const { classifyExit, superviseServer } = require('./supervise')
 
 const VERSION = require('./package.json').version
 const REPO = 'tombelieber/claude-view'
@@ -213,37 +214,65 @@ async function main() {
     env.SIDECAR_DIR = sidecarDir
   }
 
-  // Run the server, forwarding signals and exit code.
+  // Run the server under a bounded crash-supervisor (see ./supervise.js).
   //
-  // Signal handling strategy:
-  // - SIGINT: Don't forward. Terminal sends SIGINT to the entire process group,
-  //   so the child already receives it. Forwarding would double-deliver, causing
-  //   the Rust server's graceful shutdown to see two SIGINTs from one Ctrl+C.
-  // - SIGTERM/SIGHUP: Forward. These may be sent to our PID only (e.g. from
-  //   `kill` or a process manager), so the child wouldn't get them otherwise.
-  const child = spawn(binaryPath, process.argv.slice(2), { stdio: 'inherit', env })
+  // The server is long-running; an abnormal death — a panic=abort SIGABRT, an
+  // OS out-of-memory SIGKILL, or a non-zero exit — used to leave the user with
+  // a dead app until they manually relaunched. We now restart it on an abnormal
+  // exit, bounded to MAX_RESTARTS within RESTART_WINDOW_MS so a hard crash-loop
+  // gives up loudly instead of thrashing.
+  //
+  // Signal handling (intent unchanged):
+  // - SIGINT: the terminal delivers it to the whole process group, so the child
+  //   already receives it. The wrapper ignores it (so Node doesn't exit first)
+  //   and treats the child's SIGINT death as a deliberate stop — never restart.
+  // - SIGTERM/SIGHUP: forward to whichever child is currently running (it may
+  //   not get them if they were sent to our PID only); also a deliberate stop.
+  const MAX_RESTARTS = 5
+  const RESTART_WINDOW_MS = 60_000
 
   // Prevent Node from exiting on SIGINT before the child does.
   const ignoreSigint = () => {}
   process.on('SIGINT', ignoreSigint)
 
-  // Forward SIGTERM/SIGHUP — child may not receive these from process group.
-  for (const sig of ['SIGTERM', 'SIGHUP']) {
-    process.on(sig, () => child.kill(sig))
-  }
+  const supervisor = superviseServer({
+    spawn: () => spawn(binaryPath, process.argv.slice(2), { stdio: 'inherit', env }),
+    maxRestarts: MAX_RESTARTS,
+    windowMs: RESTART_WINDOW_MS,
+    now: () => Date.now(),
+    log: (msg) => console.error(msg),
+    onExit: ({ code, signal }) => {
+      // Terminal disposition: restore default SIGINT behavior, then propagate
+      // the child's fate faithfully so the parent shell sees the right status.
+      process.removeListener('SIGINT', ignoreSigint)
 
-  child.on('exit', (code, signal) => {
-    // Remove our SIGINT handler so the re-signal below uses default behavior.
-    process.removeListener('SIGINT', ignoreSigint)
+      // Reaching here with a crash disposition means the supervisor exhausted
+      // its restart budget — point the user at the evidence instead of dying
+      // silently.
+      if (classifyExit(code, signal) === 'crash') {
+        const logDir = path.join(os.homedir(), '.claude-view', 'logs')
+        console.error(
+          `\nCheck ${path.join(logDir, 'crash-*.log')} for a panic backtrace, ` +
+            `or your system log for an out-of-memory (jetsam) kill.`,
+        )
+      }
 
-    if (signal) {
-      // Child was killed by signal — re-signal ourselves so the parent shell
-      // sees the correct exit status (128 + signal number).
-      process.kill(process.pid, signal)
-    } else {
-      process.exit(code ?? 1)
-    }
+      if (signal) {
+        // Re-signal ourselves so the parent shell sees 128 + signal number.
+        process.kill(process.pid, signal)
+      } else {
+        process.exit(code ?? 1)
+      }
+    },
   })
+
+  // Forward deliberate-stop signals to whichever child is currently running.
+  for (const sig of ['SIGTERM', 'SIGHUP']) {
+    process.on(sig, () => {
+      const child = supervisor.getChild()
+      if (child) child.kill(sig)
+    })
+  }
 }
 
 main()

--- a/npx-cli/npx-cli.test.js
+++ b/npx-cli/npx-cli.test.js
@@ -60,6 +60,34 @@ function testNpxCliNoInstallStep() {
   console.log('PASS: npx-cli has no install step')
 }
 
+function testSupervisorWiring() {
+  console.log('E2E: Verifying crash-supervisor is wired and shipped...')
+
+  const npxCli = fs.readFileSync(path.join(__dirname, 'index.js'), 'utf-8')
+  assert.strictEqual(
+    npxCli.includes("require('./supervise')"),
+    true,
+    'index.js must require ./supervise',
+  )
+  assert.strictEqual(
+    npxCli.includes('superviseServer('),
+    true,
+    'index.js must call superviseServer',
+  )
+
+  // The publish trap: supervise.js MUST be in package.json files[] or the
+  // published npm package would throw MODULE_NOT_FOUND at launch.
+  const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf-8'))
+  assert.strictEqual(
+    pkg.files.includes('supervise.js'),
+    true,
+    'package.json files[] must include supervise.js so it ships to npm',
+  )
+
+  console.log('PASS: supervisor wired into index.js and included in published files')
+}
+
 testSidecarSetup()
 testNpxCliNoInstallStep()
+testSupervisorWiring()
 console.log('\nAll E2E tests passed.')

--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -57,5 +57,5 @@
   "engines": {
     "node": ">=16"
   },
-  "files": ["index.js", "README.md"]
+  "files": ["index.js", "supervise.js", "README.md"]
 }

--- a/npx-cli/supervise.js
+++ b/npx-cli/supervise.js
@@ -1,0 +1,111 @@
+// Crash-supervisor decision logic for the npx-cli launcher.
+//
+// The launcher spawns the Rust `claude-view` server as a child. Historically
+// the wrapper relayed the child's exit verbatim — so ANY abnormal death of the
+// server (a panic=abort SIGABRT, an OS OOM-kill SIGKILL, a non-zero exit) left
+// the user staring at a dead app until they manually restarted. This module
+// makes the launcher self-heal: restart the server on an abnormal exit, bounded
+// to `maxRestarts` within a rolling `windowMs` so a hard crash-loop gives up
+// loudly instead of thrashing forever.
+//
+// Pure functions, no side effects — the runtime loop in index.js injects the
+// clock and the crash history so the policy is fully testable.
+
+// Signals that mean "someone deliberately asked us to stop" — propagate, never
+// restart. Everything else that kills the process (SIGKILL/SIGABRT/SIGSEGV/...)
+// is treated as a crash worth recovering from.
+const USER_STOP_SIGNALS = new Set(['SIGINT', 'SIGTERM', 'SIGHUP'])
+
+/**
+ * Classify a child exit into one of: 'normal' | 'user-stop' | 'crash'.
+ * @param {number|null} code   exit code (null when killed by a signal)
+ * @param {string|null} signal terminating signal name (null on normal exit)
+ */
+function classifyExit(code, signal) {
+  if (signal) {
+    return USER_STOP_SIGNALS.has(signal) ? 'user-stop' : 'crash'
+  }
+  return code === 0 ? 'normal' : 'crash'
+}
+
+/**
+ * Decide whether to restart, given the recent crash history.
+ * Only crashes are restartable, and only while fewer than `maxRestarts`
+ * crashes have occurred within the trailing `windowMs`.
+ * @returns {boolean}
+ */
+function shouldRestart({ exitClass, crashTimes, now, maxRestarts, windowMs }) {
+  if (exitClass !== 'crash') return false
+  const recent = crashTimes.filter((t) => now - t < windowMs)
+  return recent.length < maxRestarts
+}
+
+/**
+ * Run a child process under a bounded crash-supervisor.
+ *
+ * Dependency-injected so the restart loop is testable without real processes:
+ *   - `spawn()`   -> returns a child (an EventEmitter emitting 'exit'/'error')
+ *   - `now()`     -> current epoch ms (injected clock)
+ *   - `log(msg)`  -> visible progress/diagnostic line
+ *   - `onExit({code, signal})` -> terminal disposition (caller maps to process exit)
+ *
+ * Restarts only abnormal deaths, at most `maxRestarts` within `windowMs`;
+ * beyond that it gives up and propagates the last disposition.
+ *
+ * @returns {{ getChild: () => any, crashCount: () => number }}
+ */
+function superviseServer({ spawn, maxRestarts, windowMs, now, log, onExit }) {
+  const crashTimes = []
+  let child = null
+
+  const launch = () => {
+    // Per-launch guard: a failed spawn can emit BOTH 'error' and 'exit'; we
+    // must act on exactly one of them.
+    let settled = false
+    const settle = (disposition, restart) => {
+      if (settled) return
+      settled = true
+      if (restart) {
+        launch()
+      } else {
+        onExit(disposition)
+      }
+    }
+
+    child = spawn()
+
+    child.on('error', (err) => {
+      // Spawn-level failure (binary missing / not executable) is a permanent
+      // install problem, not a runtime crash — surface it, don't retry.
+      log(`\nFailed to launch claude-view server: ${err.message}`)
+      settle({ code: 1, signal: null }, false)
+    })
+
+    child.on('exit', (code, signal) => {
+      const exitClass = classifyExit(code, signal)
+      if (exitClass === 'crash') {
+        const t = now()
+        if (shouldRestart({ exitClass, crashTimes, now: t, maxRestarts, windowMs })) {
+          crashTimes.push(t)
+          const reason = signal ? `signal ${signal}` : `exit code ${code}`
+          log(
+            `\nclaude-view server died (${reason}) — restarting ` +
+              `(${crashTimes.length}/${maxRestarts} within ${Math.round(windowMs / 1000)}s)...`,
+          )
+          settle(null, true)
+          return
+        }
+        log(
+          `\nclaude-view server crashed ${maxRestarts} times within ` +
+            `${Math.round(windowMs / 1000)}s — giving up.`,
+        )
+      }
+      settle({ code, signal }, false)
+    })
+  }
+
+  launch()
+  return { getChild: () => child, crashCount: () => crashTimes.length }
+}
+
+module.exports = { classifyExit, shouldRestart, superviseServer, USER_STOP_SIGNALS }

--- a/npx-cli/supervise.test.js
+++ b/npx-cli/supervise.test.js
@@ -1,0 +1,201 @@
+// Unit tests for the npx-cli crash supervisor decision logic.
+// Pure functions — no process spawning — so they run fast and hermetically
+// under plain `node npx-cli/supervise.test.js`.
+
+const assert = require('assert')
+const { EventEmitter } = require('events')
+const { classifyExit, shouldRestart, superviseServer } = require('./supervise')
+
+function test(name, fn) {
+  fn()
+  console.log(`PASS: ${name}`)
+}
+
+// Deterministic, synchronous fake `spawn`: returns a fresh EventEmitter per
+// call so the test can drive 'exit'/'error' events by hand and observe whether
+// the supervisor re-spawns.
+function makeFakeSpawn() {
+  const children = []
+  const spawn = () => {
+    const child = new EventEmitter()
+    child.kill = () => {}
+    children.push(child)
+    return child
+  }
+  return {
+    spawn,
+    children,
+    count: () => children.length,
+    last: () => children[children.length - 1],
+  }
+}
+
+// --- classifyExit: maps (code, signal) to an exit class ---
+
+test('clean exit (code 0) is "normal"', () => {
+  assert.strictEqual(classifyExit(0, null), 'normal')
+})
+
+test('non-zero exit code is "crash"', () => {
+  assert.strictEqual(classifyExit(1, null), 'crash')
+  assert.strictEqual(classifyExit(134, null), 'crash') // 128+SIGABRT style code
+})
+
+test('user-initiated stop signals are "user-stop" (never restart)', () => {
+  assert.strictEqual(classifyExit(null, 'SIGINT'), 'user-stop')
+  assert.strictEqual(classifyExit(null, 'SIGTERM'), 'user-stop')
+  assert.strictEqual(classifyExit(null, 'SIGHUP'), 'user-stop')
+})
+
+test('crash signals (OOM-kill SIGKILL, abort SIGABRT, segfault) are "crash"', () => {
+  assert.strictEqual(classifyExit(null, 'SIGKILL'), 'crash') // OS OOM-killer
+  assert.strictEqual(classifyExit(null, 'SIGABRT'), 'crash') // panic=abort
+  assert.strictEqual(classifyExit(null, 'SIGSEGV'), 'crash')
+})
+
+// --- shouldRestart: bounded restart within a rolling window ---
+
+test('restarts a crash when no recent crashes', () => {
+  assert.strictEqual(
+    shouldRestart({
+      exitClass: 'crash',
+      crashTimes: [],
+      now: 1000,
+      maxRestarts: 5,
+      windowMs: 60000,
+    }),
+    true,
+  )
+})
+
+test('never restarts a normal exit', () => {
+  assert.strictEqual(
+    shouldRestart({
+      exitClass: 'normal',
+      crashTimes: [],
+      now: 1000,
+      maxRestarts: 5,
+      windowMs: 60000,
+    }),
+    false,
+  )
+})
+
+test('never restarts a user-stop', () => {
+  assert.strictEqual(
+    shouldRestart({
+      exitClass: 'user-stop',
+      crashTimes: [],
+      now: 1000,
+      maxRestarts: 5,
+      windowMs: 60000,
+    }),
+    false,
+  )
+})
+
+test('gives up after maxRestarts crashes within the window', () => {
+  // 5 crashes already happened in the last 60s; a 6th must NOT restart.
+  const crashTimes = [1000, 2000, 3000, 4000, 5000]
+  assert.strictEqual(
+    shouldRestart({ exitClass: 'crash', crashTimes, now: 6000, maxRestarts: 5, windowMs: 60000 }),
+    false,
+  )
+})
+
+test('restarts again once old crashes age out of the window', () => {
+  // 5 crashes, but they are all older than the 60s window relative to now.
+  const crashTimes = [1000, 2000, 3000, 4000, 5000]
+  assert.strictEqual(
+    shouldRestart({ exitClass: 'crash', crashTimes, now: 70000, maxRestarts: 5, windowMs: 60000 }),
+    true,
+  )
+})
+
+// --- superviseServer: the restart loop (injected spawn/clock/exit) ---
+
+test('respawns once on a crash, then propagates the subsequent clean exit', () => {
+  const f = makeFakeSpawn()
+  const exits = []
+  superviseServer({
+    spawn: f.spawn,
+    maxRestarts: 5,
+    windowMs: 60000,
+    now: () => 1000,
+    log: () => {},
+    onExit: (d) => exits.push(d),
+  })
+  f.last().emit('exit', 1, null) // crash → should restart
+  f.last().emit('exit', 0, null) // clean → should propagate, no restart
+  assert.strictEqual(f.count(), 2, 'should have spawned twice (initial + 1 restart)')
+  assert.deepStrictEqual(exits, [{ code: 0, signal: null }])
+})
+
+test('never respawns on a clean exit', () => {
+  const f = makeFakeSpawn()
+  const exits = []
+  superviseServer({
+    spawn: f.spawn,
+    maxRestarts: 5,
+    windowMs: 60000,
+    now: () => 1,
+    log: () => {},
+    onExit: (d) => exits.push(d),
+  })
+  f.last().emit('exit', 0, null)
+  assert.strictEqual(f.count(), 1, 'clean exit must not respawn')
+  assert.deepStrictEqual(exits, [{ code: 0, signal: null }])
+})
+
+test('never respawns on a deliberate stop signal', () => {
+  const f = makeFakeSpawn()
+  const exits = []
+  superviseServer({
+    spawn: f.spawn,
+    maxRestarts: 5,
+    windowMs: 60000,
+    now: () => 1,
+    log: () => {},
+    onExit: (d) => exits.push(d),
+  })
+  f.last().emit('exit', null, 'SIGTERM')
+  assert.strictEqual(f.count(), 1, 'SIGTERM must not respawn')
+  assert.deepStrictEqual(exits, [{ code: null, signal: 'SIGTERM' }])
+})
+
+test('gives up after maxRestarts crashes within the window', () => {
+  const f = makeFakeSpawn()
+  const exits = []
+  superviseServer({
+    spawn: f.spawn,
+    maxRestarts: 2,
+    windowMs: 60000,
+    now: () => 5000,
+    log: () => {},
+    onExit: (d) => exits.push(d),
+  })
+  f.last().emit('exit', 1, null) // crash 1 → restart (1/2)
+  f.last().emit('exit', 1, null) // crash 2 → restart (2/2)
+  f.last().emit('exit', 1, null) // crash 3 → budget exhausted → propagate
+  assert.strictEqual(f.count(), 3, 'initial + exactly 2 restarts, then give up')
+  assert.deepStrictEqual(exits, [{ code: 1, signal: null }])
+})
+
+test('a spawn error is surfaced and not retried', () => {
+  const f = makeFakeSpawn()
+  const exits = []
+  superviseServer({
+    spawn: f.spawn,
+    maxRestarts: 5,
+    windowMs: 60000,
+    now: () => 1,
+    log: () => {},
+    onExit: (d) => exits.push(d),
+  })
+  f.last().emit('error', new Error('ENOENT'))
+  assert.strictEqual(f.count(), 1, 'spawn error must not respawn')
+  assert.strictEqual(exits.length, 1)
+  assert.strictEqual(exits[0].code, 1)
+})
+
+console.log('\nAll supervise.js tests passed.')


### PR DESCRIPTION
## Symptom

User report (v0.42.0): *"very unstable — runs ~10 minutes and down again; restart fixes it; reinstall does not."* Meanwhile the server runs **8+ days unbroken on a high-RAM dev box** with zero panics/OOM. "Restart fixes, reinstall doesn't" ⇒ accumulated **runtime state**, not the binary.

## Root cause — a fault-isolation failure stacked on a recurring O(N²) memory spike

There is no single bug; it's three interacting defects, all of which a high-RAM `unwind` dev box silently absorbs:

| Layer | Defect |
|---|---|
| **Amplifier 1** | `[profile.dist] panic = "abort"` — a panic in *any* background tokio task (indexer / git-sync / file-watcher / a request handler hitting unusual `~/.claude` data) `SIGABRT`s the **whole** process. dev/release profiles use `panic="unwind"`, which isolates the task — **this is exactly why it never reproduced in development.** |
| **Amplifier 2** | `npx-cli/index.js` relayed the child's exit with **no restart** → server death = whole app "down". |
| **Trigger** | The parallel indexer cloned the full session-keyed `hints` **and** `existing_map` maps **per file** → **O(N²)** peak heap, re-firing on **every ~120s periodic re-scan**. A 3k-session corpus is nothing on 64GB+, but marches an 8–16GB Mac into swap → OOM within minutes. `~10 min` ≈ 5 re-scan cycles. |

## Fix

1. **Indexer O(N²) → O(N)** (`phase_parse.rs`): `Arc`-share the read-only lookup maps instead of deep-cloning per file. Closures only `.get()`, so behavior is byte-identical.
2. **dist `panic="abort"` → `"unwind"`** (`Cargo.toml`): restores tokio per-task isolation in the shipped build; one bad record can't crash the server. Panic hook still writes `~/.claude-view/logs/crash-*.log`. Cost: ~2.9MB unwind tables.
3. **Bounded crash-supervisor** (`npx-cli/supervise.js`): restarts the server on abnormal exit (non-zero / `SIGKILL` OOM-kill / `SIGABRT`), at most **5 within 60s**, then gives up loudly pointing at `crash-*.log`. Never restarts a clean exit or user `SIGINT`/`SIGTERM`/`SIGHUP`. Added to `package.json` `files[]` so it ships to npm.

## Verification

- `cq check --workspace` ✓ · `cq clippy` ✓ · **rust-test 3094/3094** ✓ (pre-push gate)
- `claude-view-db` lib: 378/378 ✓ · indexer safety-nets 70/70 ✓
- npx supervisor: 14 unit tests + 3 wiring/publish-trap guards ✓

## Diagnostic for future reports

`crash-*.log` present → Rust panic (fix #2 cures). Absent → OS OOM-kill `SIGKILL` (fixes #1/#3 cure).

## Deferred (separate PR, chat-only)

Sidecar `ws-handler.ts` re-serializes the entire conversation snapshot on every SDK event (O(N²)) + `node` spawned with no V8 heap cap. Real, but only affects live-chat users; the correct fix is incremental snapshots, not an arbitrary cap that would regress heavy sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)