### PR TITLE
fix(sidecar): WS backpressure + O(1) tool lookup for long live-chat sessions

### DIFF
--- a/sidecar/src/memory-caps.test.ts
+++ b/sidecar/src/memory-caps.test.ts
@@ -153,6 +153,7 @@ describe('StreamAccumulator memory caps', () => {
       modelUsage: {},
       usage: { input_tokens: 10, output_tokens: 5 },
       stopReason: 'end_turn',
+      result: 'ok',
       permissionDenials: [],
     })
 

--- a/sidecar/src/stream-accumulator.ts
+++ b/sidecar/src/stream-accumulator.ts
@@ -270,6 +270,11 @@ function truncateJson(value: Record<string, unknown>, maxBytes: number): Record<
 export class StreamAccumulator {
   private blocks: ConversationBlock[] = []
   private currentAssistant: AssistantBlock | null = null
+  /** toolUseId → its ToolExecution, for O(1) lookup from tool_use_result /
+   *  tool_progress / tool_summary. Previously these scanned every block and
+   *  allocated a fresh getBlocks() array per call — O(N) CPU + GC churn per
+   *  tool event on long sessions. Kept in sync on tool start and block eviction. */
+  private toolExecutionIndex = new Map<string, ToolExecution>()
   private pushCounter = 0
   private initialized = false
   private buffer: { event: ServerEvent | SequencedEvent; raw?: Record<string, unknown> }[] = []
@@ -290,7 +295,13 @@ export class StreamAccumulator {
     while (dropped < excess && this.blocks.length > 0) {
       const idx = this.blocks.findIndex((b) => b.type !== 'turn_boundary')
       if (idx === -1) break
-      this.blocks.splice(idx, 1)
+      const [removed] = this.blocks.splice(idx, 1)
+      // Drop evicted tool executions from the index so it can't outgrow MAX_BLOCKS.
+      if (removed?.type === 'assistant') {
+        for (const seg of removed.segments) {
+          if (seg.kind === 'tool') this.toolExecutionIndex.delete(seg.execution.toolUseId)
+        }
+      }
       dropped++
     }
     if (!this.evictionWarned && dropped > 0) {
@@ -349,6 +360,7 @@ export class StreamAccumulator {
     this.currentAssistant = null
     this.initialized = false
     this.buffer = []
+    this.toolExecutionIndex.clear()
   }
 
   private handleEvent(event: ServerEvent | SequencedEvent): void {
@@ -534,6 +546,7 @@ export class StreamAccumulator {
       status: 'running',
     }
     assistant.segments.push({ kind: 'tool', execution })
+    this.toolExecutionIndex.set(execution.toolUseId, execution)
   }
 
   private handleToolUseResult(event: ToolUseResult): void {
@@ -680,16 +693,10 @@ export class StreamAccumulator {
   }
 
   private findToolExecution(toolUseId: string): ToolExecution | undefined {
-    const allBlocks = this.getBlocks()
-    for (const block of allBlocks) {
-      if (block.type !== 'assistant') continue
-      for (const seg of block.segments) {
-        if (seg.kind === 'tool' && seg.execution.toolUseId === toolUseId) {
-          return seg.execution
-        }
-      }
-    }
-    return undefined
+    // O(1) lookup. Executions are inserted on tool_use_start (covering both the
+    // in-flight currentAssistant and finalized blocks, which share the same
+    // object reference) and removed on block eviction.
+    return this.toolExecutionIndex.get(toolUseId)
   }
 
   private pushInteraction(

--- a/sidecar/src/ws-backpressure.test.ts
+++ b/sidecar/src/ws-backpressure.test.ts
@@ -1,0 +1,103 @@
+// Backpressure tests for ws-handler: a slow/stalled client must not be able to
+// make the sidecar buffer unbounded full-conversation snapshots in its ws send
+// queue (a real OOM vector for long live-chat sessions). The happy path (empty
+// buffer, or a mock ws with no bufferedAmount) MUST behave exactly as before.
+import { describe, expect, it, vi } from 'vitest'
+import { handleWebSocket } from './ws-handler.js'
+
+// Build a mock ws + session and capture the server→client `onMessage` callback
+// that ws-handler registers on session.emitter. Connect happens with an empty
+// buffer; the test sets ws.bufferedAmount afterward to simulate a slow client.
+function setup() {
+  const sent: string[] = []
+  let onMessage: ((msg: unknown) => void) | undefined
+  // biome-ignore lint/suspicious/noExplicitAny: test mock
+  const ws: any = {
+    send: vi.fn((s: string) => sent.push(s)),
+    close: vi.fn(),
+    readyState: 1,
+    OPEN: 1,
+    bufferedAmount: 0,
+    on: vi.fn(),
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: test mock
+  const session: any = {
+    wsClients: new Set(),
+    lastSessionInit: null,
+    state: 'active',
+    emitter: {
+      on: vi.fn((evt: string, cb: (msg: unknown) => void) => {
+        if (evt === 'message') onMessage = cb
+      }),
+      removeListener: vi.fn(),
+    },
+    permissions: { drainInteractive: vi.fn() },
+    accumulator: {
+      getBlocks: vi.fn().mockReturnValue([{ type: 'user', id: 'u1', text: 'hi', timestamp: 0 }]),
+    },
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: test mock
+  const registry: any = { get: vi.fn().mockReturnValue(session), emitSequenced: vi.fn() }
+  handleWebSocket(ws, 'ctrl-1', registry)
+  if (!onMessage) throw new Error('onMessage was not registered')
+  return {
+    ws,
+    sent,
+    emit: (m: unknown) => (onMessage as (msg: unknown) => void)(m),
+    resetSent: () => {
+      sent.length = 0
+    },
+  }
+}
+
+const typesOf = (sent: string[]) => sent.map((s) => JSON.parse(s).type)
+
+describe('ws-handler backpressure', () => {
+  it('sends blocks_update for a block-producing event when the buffer is empty (happy path)', () => {
+    const h = setup()
+    h.ws.bufferedAmount = 0
+    h.resetSent()
+    h.emit({ type: 'assistant_text', text: 'hello', messageId: 'm1', parentToolUseId: null })
+    const types = typesOf(h.sent)
+    expect(types).toContain('assistant_text')
+    expect(types).toContain('blocks_update')
+    expect(h.ws.close).not.toHaveBeenCalled()
+  })
+
+  it('treats a missing bufferedAmount as zero backpressure (mock-safe — preserves existing tests)', () => {
+    const h = setup()
+    h.ws.bufferedAmount = undefined
+    h.resetSent()
+    h.emit({
+      type: 'tool_use_start',
+      toolName: 'Bash',
+      toolInput: {},
+      toolUseId: 't1',
+      messageId: 'm1',
+    })
+    expect(typesOf(h.sent)).toContain('blocks_update')
+    expect(h.ws.close).not.toHaveBeenCalled()
+  })
+
+  it('skips the redundant full-snapshot blocks_update when the buffer is over the soft limit', () => {
+    const h = setup()
+    h.ws.bufferedAmount = 8 * 1024 * 1024 // 8 MB — over the soft limit
+    h.resetSent()
+    h.emit({ type: 'assistant_text', text: 'hello', messageId: 'm1', parentToolUseId: null })
+    const types = typesOf(h.sent)
+    // The small raw event still flows (it's the streaming delta the client needs)...
+    expect(types).toContain('assistant_text')
+    // ...but we do NOT pile another full conversation snapshot onto a backed-up
+    // socket. The next under-limit event or turn_complete carries the latest state.
+    expect(types).not.toContain('blocks_update')
+    expect(h.ws.close).not.toHaveBeenCalled()
+  })
+
+  it('closes a client whose send buffer exceeds the hard limit (dead/too-slow client)', () => {
+    const h = setup()
+    h.ws.bufferedAmount = 64 * 1024 * 1024 // 64 MB — client is not draining; protect the server
+    h.resetSent()
+    h.emit({ type: 'assistant_text', text: 'hello', messageId: 'm1', parentToolUseId: null })
+    expect(h.ws.close).toHaveBeenCalled()
+  })
+})

--- a/sidecar/src/ws-handler.ts
+++ b/sidecar/src/ws-handler.ts
@@ -51,6 +51,37 @@ const BLOCK_PRODUCING_EVENTS = new Set([
   // stream_delta (non-text) is handled by isBlockStart. pong produces no block.
 ])
 
+// WS backpressure thresholds. A live conversation snapshot (getBlocks()) can be
+// large, and a block-producing event fires one on nearly every streaming tick.
+// If a client (backgrounded tab, slow link) stops draining, queuing a fresh full
+// snapshot per event grows the ws send buffer without bound — a sidecar OOM
+// vector for long sessions. So we (a) skip the redundant full snapshot while the
+// buffer is over SOFT (the next under-limit event or turn_complete carries the
+// latest full state — getBlocks() is always current and the client merges by id),
+// and (b) close a client that blows past HARD (it is effectively dead; retaining
+// its queue would leak memory). Small per-event messages still flow until HARD.
+const WS_SNAPSHOT_SOFT_LIMIT_BYTES = 4 * 1024 * 1024
+const WS_CLOSE_HARD_LIMIT_BYTES = 32 * 1024 * 1024
+
+/** Bytes currently queued in the socket's send buffer. Mocks and exotic
+ *  transports may not expose `bufferedAmount`; treat absent as 0 so the happy
+ *  path (and unit-test mocks) behave exactly as before. */
+function bufferedBytes(ws: WebSocket): number {
+  return (ws as { bufferedAmount?: number }).bufferedAmount ?? 0
+}
+
+/** Send if the socket is keeping up; drop a client that has fallen too far
+ *  behind instead of letting its backlog OOM the sidecar. */
+function trySend(ws: WebSocket, payload: string): void {
+  if (ws.readyState !== ws.OPEN) return
+  if (bufferedBytes(ws) > WS_CLOSE_HARD_LIMIT_BYTES) {
+    // 1013 = "Try Again Later".
+    ws.close(1013, 'client too slow to keep up')
+    return
+  }
+  ws.send(payload)
+}
+
 export function handleWebSocket(ws: WebSocket, controlId: string, registry: SessionRegistry) {
   const session = registry.get(controlId)
   if (!session) {
@@ -94,9 +125,10 @@ export function handleWebSocket(ws: WebSocket, controlId: string, registry: Sess
     if (ws.readyState !== ws.OPEN) return
     const msg = rawMsg as ServerEvent
     if (msg.type === 'turn_complete' || msg.type === 'turn_error') {
-      ws.send(JSON.stringify({ ...msg, blocks: session.accumulator.getBlocks() }))
+      // Terminal turn state — always carries the authoritative full blocks.
+      trySend(ws, JSON.stringify({ ...msg, blocks: session.accumulator.getBlocks() }))
     } else {
-      ws.send(JSON.stringify(msg))
+      trySend(ws, JSON.stringify(msg))
       // Send blocks_update when accumulator state changes structurally:
       // - CONTENT_EVENTS: assistant_text, tool_use_start, assistant_thinking, user_message_echo
       // - content_block_start: creates the assistant block skeleton (needed for pendingText)
@@ -104,12 +136,19 @@ export function handleWebSocket(ws: WebSocket, controlId: string, registry: Sess
         msg.type === 'stream_delta' &&
         (msg as { deltaType?: string }).deltaType === 'content_block_start'
       if (BLOCK_PRODUCING_EVENTS.has(msg.type) || isBlockStart) {
-        ws.send(
-          JSON.stringify({
-            type: 'blocks_update',
-            blocks: session.accumulator.getBlocks(),
-          }),
-        )
+        // Skip the (potentially large) full snapshot while the client is behind;
+        // a later under-limit event or the turn_complete above carries the latest
+        // state. The frontend merges blocks_update by id, so dropping intermediate
+        // snapshots converges to the same result (see mergeBlocks).
+        if (bufferedBytes(ws) <= WS_SNAPSHOT_SOFT_LIMIT_BYTES) {
+          trySend(
+            ws,
+            JSON.stringify({
+              type: 'blocks_update',
+              blocks: session.accumulator.getBlocks(),
+            }),
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
## Context
Follow-up to #73 (which fixed the actual ~10-min crash). Hardens the **live-chat sidecar** against the two audit findings that survived code-level verification. Other "unbounded memory" findings were **already mitigated** by existing caps (`MAX_BLOCKS=10_000` eviction, tool-output/summary/raw-json truncation, pre-init buffer cap) — left as-is.

## Fixes
**1. WS send backpressure (`ws-handler.ts`)** — a slow/stalled client could make the sidecar queue a full-conversation snapshot per streaming event without bound → OOM. Every send now goes through `trySend()`: buffer > **32MB** → `ws.close(1013)`; the large per-event `blocks_update` is **skipped while buffer > 4MB**. Safe by construction — the frontend merges `blocks_update` by id (`mergeBlocks`) and `getBlocks()` is always the full state, so skipping intermediate snapshots converges identically; `turn_complete`/`turn_error` always carry full blocks. Absent `bufferedAmount` (mocks) → `0` → happy path unchanged.

**2. O(1) tool lookup (`stream-accumulator.ts`)** — `findToolExecution` scanned every block **and allocated a fresh `getBlocks()` array** per `tool_use_result`/`tool_progress`/`tool_summary`. Replaced with a `Map<toolUseId, ToolExecution>` index (synced on tool start, `reset()`, eviction). Behavior-identical; removes per-tool-event CPU + GC churn.

**3.** Fixed a pre-existing latent `tsc` error (a `turn_complete` fixture missing required `result`).

## Verification
- Sidecar suite **229 passed** (+4 new backpressure tests) · `tsc --noEmit` clean · bundle builds
- Pre-push: clippy + full Rust suite (3094 tests) green (no Rust changes)
- Independent adversarial review of the diff: **no regressions**

## Deferred (documented, low user-impact)
- Sidecar supervisor breaker check-and-record race + orphan-on-SIGKILL — mitigated by `kill_port_holder` on restart + `panic=unwind` running Drop.
- Async snapshot time-coalescing — would break the documented "immediately sent" contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)