### PR TITLE
feat(live-monitor): rich first-run empty state + path into history

### DIFF
--- a/apps/web/src/components/live/LiveMonitorEmptyState.stories.tsx
+++ b/apps/web/src/components/live/LiveMonitorEmptyState.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { MemoryRouter } from 'react-router-dom'
+import { LiveMonitorEmptyState } from './LiveMonitorEmptyState'
+
+/**
+ * Live Monitor first-run / no-active-sessions state.
+ *
+ * Shown when a user opens claude-view with no *active* Claude Code session —
+ * the common first-run case. Replaces the previous blank board on the default
+ * kanban view and offers a path into indexed history.
+ */
+const meta = {
+  title: 'Live/LiveMonitorEmptyState',
+  component: LiveMonitorEmptyState,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <div className="dark min-h-[420px] bg-gray-950 flex items-center justify-center">
+          <Story />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+} satisfies Meta<typeof LiveMonitorEmptyState>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Nothing running, nothing detected — pure first-run. */
+export const NoSessions: Story = {
+  args: { processCount: 0 },
+}
+
+/** A Claude Code process is running but hasn't reported a session yet. */
+export const ProcessDetected: Story = {
+  args: { processCount: 1 },
+}
+
+/** Several processes detected, waiting on hook reports. */
+export const MultipleProcesses: Story = {
+  args: { processCount: 3 },
+}

--- a/apps/web/src/components/live/LiveMonitorEmptyState.test.tsx
+++ b/apps/web/src/components/live/LiveMonitorEmptyState.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { LiveMonitorEmptyState } from './LiveMonitorEmptyState'
+
+function renderEmptyState(processCount: number) {
+  return render(
+    <MemoryRouter>
+      <LiveMonitorEmptyState processCount={processCount} />
+    </MemoryRouter>,
+  )
+}
+
+describe('LiveMonitorEmptyState', () => {
+  it('always offers a path into session history (fixes the first-run dead-end)', () => {
+    renderEmptyState(0)
+    const cta = screen.getByRole('link', { name: /browse your past sessions/i })
+    expect(cta).toHaveAttribute('href', '/sessions')
+  })
+
+  it('guides the user to start a session when none are detected', () => {
+    renderEmptyState(0)
+    expect(screen.getByText(/no claude sessions running right now/i)).toBeInTheDocument()
+    expect(screen.getByText(/watching for sessions/i)).toBeInTheDocument()
+    // No false "processes detected" claim when there are none.
+    expect(screen.queryByText(/process(es)? detected/i)).not.toBeInTheDocument()
+  })
+
+  it('surfaces detected processes with correct pluralization', () => {
+    renderEmptyState(3)
+    expect(screen.getByText(/3 Claude processes detected/i)).toBeInTheDocument()
+    expect(screen.getByText(/report in via hooks/i)).toBeInTheDocument()
+  })
+
+  it('uses the singular noun for a single detected process', () => {
+    renderEmptyState(1)
+    expect(screen.getByText(/1 Claude process detected/i)).toBeInTheDocument()
+    expect(screen.queryByText(/processes detected/i)).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/live/LiveMonitorEmptyState.tsx
+++ b/apps/web/src/components/live/LiveMonitorEmptyState.tsx
@@ -1,0 +1,82 @@
+import { Activity, ArrowRight } from 'lucide-react'
+import { Link } from 'react-router-dom'
+
+interface LiveMonitorEmptyStateProps {
+  /**
+   * Claude Code processes the server has detected but that have not yet
+   * reported a session via hooks. Drives the "detected, waiting" copy.
+   */
+  processCount: number
+}
+
+/**
+ * First-run / no-active-sessions state for the Live Monitor.
+ *
+ * The live monitor is the product's hook, but a user with no *active* Claude
+ * Code session would otherwise land on a blank board — and the default kanban
+ * view shipped no empty guidance at all. This turns that dead-end into a clear
+ * "what to do to make a session appear" plus a path into the history the user
+ * already has indexed (the second most-used surface).
+ *
+ * Pure presentational. The server-derived `processCount` is injected so this
+ * stays trivially testable and story-able.
+ */
+export function LiveMonitorEmptyState({ processCount }: LiveMonitorEmptyStateProps) {
+  const hasProcesses = processCount > 0
+
+  return (
+    <div className="flex flex-col items-center justify-center text-center py-16 px-6">
+      <div className="relative mb-5">
+        <span
+          className="absolute inset-0 -z-10 rounded-full bg-green-500/15 blur-xl animate-pulse"
+          aria-hidden="true"
+        />
+        <Activity className="w-10 h-10 text-gray-400 dark:text-gray-500" strokeWidth={1.5} />
+      </div>
+
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+        No Claude sessions running right now
+      </h2>
+
+      {hasProcesses ? (
+        <>
+          <div className="mt-3 inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-green-500/10 text-green-600 dark:text-green-400 text-sm font-medium">
+            <span className="inline-block h-2 w-2 rounded-full bg-green-500 animate-pulse" />
+            {processCount} Claude {processCount === 1 ? 'process' : 'processes'} detected
+          </div>
+          <p className="mt-3 max-w-sm text-sm text-gray-500 dark:text-gray-400">
+            Sessions appear as they report in via hooks. Try sending a message in one of your Claude
+            Code terminals.
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="mt-2 max-w-sm text-sm text-gray-500 dark:text-gray-400">
+            Start a session in your terminal and it streams in here the moment Claude Code reports
+            its first message.
+          </p>
+          <div className="mt-4 inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-gray-500/10 text-gray-500 dark:text-gray-400 text-xs font-medium">
+            <span className="inline-block h-1.5 w-1.5 rounded-full bg-green-500 animate-pulse" />
+            Watching for sessions…
+          </div>
+        </>
+      )}
+
+      <div className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-800 w-full max-w-sm">
+        <p className="mb-3 text-xs text-gray-400 dark:text-gray-500">
+          Or pick up where you left off
+        </p>
+        <Link
+          to="/sessions"
+          className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-indigo-500 text-sm font-medium text-white transition-colors hover:bg-indigo-400"
+        >
+          Browse your past sessions
+          <ArrowRight className="w-4 h-4" />
+        </Link>
+        <p className="mt-3 text-xs text-gray-400 dark:text-gray-500">
+          Every past session is indexed and searchable.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/LiveMonitorPage.tsx
+++ b/apps/web/src/pages/LiveMonitorPage.tsx
@@ -1,14 +1,15 @@
 import type { DockviewApi } from 'dockview-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useOutletContext, useSearchParams } from 'react-router-dom'
-import { NewCliSessionButton } from '../components/cli-terminal'
 import { LiveMonitorSkeleton } from '../components/LoadingStates'
+import { NewCliSessionButton } from '../components/cli-terminal'
 import { CostTokenPopover } from '../components/live/CostTokenPopover'
 import { HarnessKanbanView } from '../components/live/HarnessKanbanView'
 import { KanbanView } from '../components/live/KanbanView'
 import { KeyboardShortcutHelp } from '../components/live/KeyboardShortcutHelp'
 import { ListView } from '../components/live/ListView'
 import { LiveFilterBar } from '../components/live/LiveFilterBar'
+import { LiveMonitorEmptyState } from '../components/live/LiveMonitorEmptyState'
 import { MobileTabBar } from '../components/live/MobileTabBar'
 import { MonitorView } from '../components/live/MonitorView'
 import { OAuthUsagePill } from '../components/live/OAuthUsagePill'
@@ -30,18 +31,18 @@ import {
   type LiveSummary,
   sessionTotalCost,
 } from '../components/live/use-live-sessions'
-import {
-  useActiveSessions,
-  useRecentlyClosed,
-  useLiveSummary,
-  useIsLiveConnected,
-  useIsLiveInitialized,
-  useLiveSessionStore,
-  useStalledSessions,
-} from '../store/live-session-store'
 import type { IndexingProgress } from '../hooks/use-indexing-progress'
 import { useTrackEvent } from '../hooks/use-track-event'
 import { useLiveCommandStore } from '../store/live-command-context'
+import {
+  useActiveSessions,
+  useIsLiveConnected,
+  useIsLiveInitialized,
+  useLiveSessionStore,
+  useLiveSummary,
+  useRecentlyClosed,
+  useStalledSessions,
+} from '../store/live-session-store'
 import { useMonitorStore } from '../store/monitor-store'
 
 function resolveInitialView(searchParams: URLSearchParams): LiveViewMode {
@@ -482,108 +483,94 @@ export function LiveMonitorPage() {
         <div
           className={`max-w-7xl mx-auto w-full ${viewMode === 'kanban' || viewMode === 'monitor' || viewMode === 'harness' ? 'flex-1 min-h-0 flex flex-col' : ''}`}
         >
-          {/* View content */}
-          {viewMode === 'grid' && (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-              {visibleSessions.map((session) => (
-                <div
-                  key={session.id}
-                  data-session-id={session.id}
-                  className={selectedId === session.id ? 'ring-2 ring-amber-500 rounded-lg' : ''}
-                >
-                  <SessionCard
-                    session={session}
-                    stalledSessions={stalledSessions}
-                    currentTime={currentTime}
-                    onClickOverride={() => handleSelectSession(session.id)}
-                  />
+          {/* View content — when there are no active sessions at all, show the
+              rich empty state in EVERY view (the default kanban view previously
+              shipped no first-run guidance); otherwise render the selected view. */}
+          {sessions.length === 0 && isConnected ? (
+            <LiveMonitorEmptyState processCount={serverSummary?.processCount ?? 0} />
+          ) : (
+            <>
+              {viewMode === 'grid' && (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                  {visibleSessions.map((session) => (
+                    <div
+                      key={session.id}
+                      data-session-id={session.id}
+                      className={
+                        selectedId === session.id ? 'ring-2 ring-amber-500 rounded-lg' : ''
+                      }
+                    >
+                      <SessionCard
+                        session={session}
+                        stalledSessions={stalledSessions}
+                        currentTime={currentTime}
+                        onClickOverride={() => handleSelectSession(session.id)}
+                      />
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
-          )}
+              )}
 
-          {viewMode === 'list' && (
-            <ListView
-              sessions={visibleSessions}
-              selectedId={selectedId}
-              onSelect={handleSelectSession}
-            />
-          )}
+              {viewMode === 'list' && (
+                <ListView
+                  sessions={visibleSessions}
+                  selectedId={selectedId}
+                  onSelect={handleSelectSession}
+                />
+              )}
 
-          {viewMode === 'kanban' && (
-            <KanbanView
-              sessions={visibleSessions}
-              selectedId={selectedId}
-              onSelect={handleSelectSession}
-              onCardClick={handleSelectSession}
-              stalledSessions={stalledSessions}
-              currentTime={currentTime}
-              groupBy={groupBy}
-              projectGroups={projectGroups}
-              isCollapsed={isCollapsed}
-              toggleCollapse={toggleCollapse}
-              recentlyClosed={recentlyClosed}
-              onDismiss={dismissSession}
-              onDismissAll={dismissAllClosed}
-              showClosed={showClosed}
-            />
-          )}
+              {viewMode === 'kanban' && (
+                <KanbanView
+                  sessions={visibleSessions}
+                  selectedId={selectedId}
+                  onSelect={handleSelectSession}
+                  onCardClick={handleSelectSession}
+                  stalledSessions={stalledSessions}
+                  currentTime={currentTime}
+                  groupBy={groupBy}
+                  projectGroups={projectGroups}
+                  isCollapsed={isCollapsed}
+                  toggleCollapse={toggleCollapse}
+                  recentlyClosed={recentlyClosed}
+                  onDismiss={dismissSession}
+                  onDismissAll={dismissAllClosed}
+                  showClosed={showClosed}
+                />
+              )}
 
-          {viewMode === 'monitor' && (
-            <MonitorView
-              sessions={visibleSessions}
-              onSelectSession={handleMonitorExpand}
-              onDockApiReady={(api) => {
-                dockviewApiRef.current = api
-              }}
-            />
-          )}
+              {viewMode === 'monitor' && (
+                <MonitorView
+                  sessions={visibleSessions}
+                  onSelectSession={handleMonitorExpand}
+                  onDockApiReady={(api) => {
+                    dockviewApiRef.current = api
+                  }}
+                />
+              )}
 
-          {viewMode === 'harness' && (
-            <HarnessKanbanView
-              sessions={visibleSessions}
-              selectedId={selectedId}
-              onSelect={handleSelectSession}
-              onCardClick={handleSelectSession}
-              stalledSessions={stalledSessions}
-              currentTime={currentTime}
-              groupBy={groupBy}
-              projectGroups={projectGroups}
-              isCollapsed={isCollapsed}
-              toggleCollapse={toggleCollapse}
-            />
-          )}
+              {viewMode === 'harness' && (
+                <HarnessKanbanView
+                  sessions={visibleSessions}
+                  selectedId={selectedId}
+                  onSelect={handleSelectSession}
+                  onCardClick={handleSelectSession}
+                  stalledSessions={stalledSessions}
+                  currentTime={currentTime}
+                  groupBy={groupBy}
+                  projectGroups={projectGroups}
+                  isCollapsed={isCollapsed}
+                  toggleCollapse={toggleCollapse}
+                />
+              )}
 
-          {/* Empty state — skip for kanban and harness (columns have their own emptyMessage) */}
-          {visibleSessions.length === 0 &&
-            isConnected &&
-            viewMode !== 'kanban' &&
-            viewMode !== 'harness' && (
-              <div className="text-center text-gray-400 dark:text-gray-500 py-16">
-                <div className="text-4xl mb-4">~</div>
-                {sessions.length === 0 ? (
-                  serverSummary && serverSummary.processCount > 0 ? (
-                    <>
-                      <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-green-500/10 text-green-500 text-sm font-medium mb-3">
-                        <span className="inline-block h-2 w-2 rounded-full bg-green-500 animate-pulse" />
-                        {serverSummary.processCount} Claude{' '}
-                        {serverSummary.processCount === 1 ? 'process' : 'processes'} detected
-                      </div>
-                      <div className="text-sm">Sessions appear as they report in via hooks.</div>
-                      <div className="text-xs mt-1 text-gray-500 dark:text-gray-600">
-                        Try sending a message in one of your Claude Code terminals.
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <div className="text-sm">No active Claude Code sessions detected.</div>
-                      <div className="text-xs mt-1">
-                        Start a session in your terminal and it will appear here.
-                      </div>
-                    </>
-                  )
-                ) : (
-                  <>
+              {/* Filtered-empty — sessions exist but none match the active filters
+                  (kanban/harness columns render their own per-column emptyMessage). */}
+              {visibleSessions.length === 0 &&
+                isConnected &&
+                viewMode !== 'kanban' &&
+                viewMode !== 'harness' && (
+                  <div className="text-center text-gray-400 dark:text-gray-500 py-16">
+                    <div className="text-4xl mb-4">~</div>
                     <div className="text-sm">No sessions match your filters.</div>
                     <div className="text-xs mt-1">
                       <button
@@ -594,10 +581,10 @@ export function LiveMonitorPage() {
                         Clear filters
                       </button>
                     </div>
-                  </>
+                  </div>
                 )}
-              </div>
-            )}
+            </>
+          )}
 
           {/* Recently closed sessions — grid and list views only */}
           {(viewMode === 'grid' || viewMode === 'list') && (


### PR DESCRIPTION
## What

Adds a proper first-run / no-active-sessions state to the Live Monitor.

**Before:** opening claude-view with no *active* Claude Code session showed a blank board — and the **default kanban view** rendered no empty-state guidance at all (the old empty state was skipped for `kanban`/`harness`).

**After:** every view shows a clear state when there are zero active sessions — what to do to make a session appear, plus a one-click path into indexed session history, so first-run is never a dead-end.

## Changes
- New `LiveMonitorEmptyState` component — presentational, `processCount` injected (trivially testable + story-able).
- `LiveMonitorPage` renders it in **all** view modes when there are zero active sessions; filtered-empty ("no sessions match your filters") and recently-closed behavior unchanged.
- Unit test + Storybook story (`Live/LiveMonitorEmptyState`).

## Verification
- ✅ `vitest` — 4/4 pass (copy, singular/plural process count, CTA → `/sessions`)
- ✅ `tsc --noEmit` — clean
- ✅ `biome check` — clean
- ✅ Rendered in Storybook, both variants (no-sessions / process-detected)

## Note
Conservative, additive, reversible treatment (no change to the live experience when sessions exist). Two richer alternatives were mocked up (lead-with-recent-sessions; first-run tour) — easy to swap if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)