### PR TITLE
fix(test): correct stale tmux-tier expectation in useInteractionResponder test

### DIFF
--- a/apps/web/src/hooks/__tests__/use-interaction-responder.test.ts
+++ b/apps/web/src/hooks/__tests__/use-interaction-responder.test.ts
@@ -63,9 +63,13 @@ describe('useInteractionResponder', () => {
     expect(typeof result.current).toBe('function')
   })
 
-  it('returns a function when ownership tier is tmux', () => {
+  it('returns undefined when ownership is tmux-only (read-only — take over to drive)', () => {
+    // Control v2 PR-2 deliberately narrowed interactivity to SDK-controlled
+    // sessions only (was sdk||tmux). A tmux-owned-only CLI session is a
+    // read-only mirror — never inject a response into the CLI's lineage; take
+    // over (fork to SDK) to drive it. (寧願唔顯示，都唔顯示錯嘅嘢.)
     const { result } = renderHook(() => useInteractionResponder('sess-1', tmuxOwnership))
-    expect(typeof result.current).toBe('function')
+    expect(result.current).toBeUndefined()
   })
 
   it('calls fetch with correct URL and body', async () => {


### PR DESCRIPTION
Release-blocking fix surfaced by `release.sh` ci-local (gate 3, TS tests).

Control v2 PR-2 (`5752ec72`) deliberately narrowed `useInteractionResponder` to **SDK-controlled sessions only** (was `sdk||tmux`) — a tmux-owned-only CLI session is a read-only mirror (take over / fork to SDK to drive it; never inject a response into the CLI's lineage). That PR updated the hook + doc comment but **missed this test**, which still asserted `tmux → function`. The per-PR push gate runs Rust tests only, so it surfaced only now at release-time ci-local.

Fix: assert `tmux-only → undefined` (read-only), matching the intended design. **No production code change** — the hook is correct.

Verification: `apps/web` suite **2170 passed** (was 2169 + 1 failed); ci-local non-Rust gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)