### PR TITLE
feat(timeline): surface CC promptSource origin on user messages

### DIFF
--- a/apps/web/src/types/generated/UserBlock.ts
+++ b/apps/web/src/types/generated/UserBlock.ts
@@ -12,6 +12,12 @@ export type UserBlock = {
   parentUuid?: string | null
   isSidechain?: boolean | null
   agentId?: string | null
+  /**
+   * Origin of the prompt as tagged by the Claude Code CLI: "typed" (human),
+   * "sdk" (Agent SDK injected), or "system" (system-generated). Verbatim raw
+   * field — absent on older sessions. See block_accumulator::handlers.
+   */
+  promptSource?: string | null
   images?: Array<ImageContent>
   rawJson?: any
 }

--- a/crates/core/src/block_accumulator/handlers.rs
+++ b/crates/core/src/block_accumulator/handlers.rs
@@ -56,6 +56,10 @@ impl BlockAccumulator {
                     .get("agentId")
                     .and_then(|a| a.as_str())
                     .map(String::from),
+                prompt_source: entry
+                    .get("promptSource")
+                    .and_then(|p| p.as_str())
+                    .map(String::from),
                 images: vec![],
                 raw_json: None,
             }));
@@ -144,6 +148,10 @@ impl BlockAccumulator {
             agent_id: entry
                 .get("agentId")
                 .and_then(|a| a.as_str())
+                .map(String::from),
+            prompt_source: entry
+                .get("promptSource")
+                .and_then(|p| p.as_str())
                 .map(String::from),
             images: blocks.images,
             raw_json: None,

--- a/crates/core/src/block_accumulator/tests_regression.rs
+++ b/crates/core/src/block_accumulator/tests_regression.rs
@@ -178,6 +178,7 @@ fn regression_string_content_preserves_all_fields() {
         "permissionMode": "bypassPermissions",
         "isSidechain": true,
         "agentId": "agent-xyz",
+        "promptSource": "system",
         "timestamp": "2026-04-04T12:30:00.000Z"
     }));
     let blocks = acc.finalize();
@@ -189,11 +190,43 @@ fn regression_string_content_preserves_all_fields() {
         assert_eq!(u.permission_mode.as_deref(), Some("bypassPermissions"));
         assert_eq!(u.is_sidechain, Some(true));
         assert_eq!(u.agent_id.as_deref(), Some("agent-xyz"));
+        assert_eq!(u.prompt_source.as_deref(), Some("system"));
         assert!(u.images.is_empty());
         assert!(u.timestamp > 0.0);
     } else {
         panic!("Expected UserBlock");
     }
+}
+
+#[test]
+fn regression_prompt_source_parsed_from_array_content() {
+    // promptSource (CC prompt-origin tag: typed | sdk | system) must flow
+    // from the raw `user` record onto UserBlock via the array-content path,
+    // and be absent (None) when the CLI omits it (older sessions).
+    let mut acc = BlockAccumulator::new();
+    acc.process_line(&serde_json::json!({
+        "type": "user",
+        "uuid": "u-sdk",
+        "message": {"content": [{"type": "text", "text": "injected prompt"}]},
+        "promptSource": "sdk",
+        "timestamp": "2026-04-04T12:30:00.000Z"
+    }));
+    acc.process_line(&serde_json::json!({
+        "type": "user",
+        "uuid": "u-legacy",
+        "message": {"content": [{"type": "text", "text": "older session, no tag"}]},
+        "timestamp": "2026-04-04T12:31:00.000Z"
+    }));
+    let blocks = acc.finalize();
+    assert_eq!(blocks.len(), 2);
+    let sources: Vec<Option<&str>> = blocks
+        .iter()
+        .filter_map(|b| match b {
+            ConversationBlock::User(u) => Some(u.prompt_source.as_deref()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(sources, vec![Some("sdk"), None]);
 }
 
 #[test]

--- a/crates/server/src/routes/sessions/messages.rs
+++ b/crates/server/src/routes/sessions/messages.rs
@@ -341,6 +341,7 @@ mod tests {
             parent_uuid: None,
             is_sidechain: None,
             agent_id: None,
+            prompt_source: None,
             images: vec![],
             raw_json: None,
         });
@@ -355,6 +356,7 @@ mod tests {
             parent_uuid: None,
             is_sidechain: None,
             agent_id: None,
+            prompt_source: None,
             images: vec![],
             raw_json: None,
         });
@@ -418,6 +420,7 @@ mod tests {
             parent_uuid: None,
             is_sidechain: None,
             agent_id: None,
+            prompt_source: None,
             images: vec![],
             raw_json: None,
         });

--- a/crates/types/src/block_types.rs
+++ b/crates/types/src/block_types.rs
@@ -81,6 +81,11 @@ pub struct UserBlock {
     pub is_sidechain: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_id: Option<String>,
+    /// Origin of the prompt as tagged by the Claude Code CLI: "typed" (human),
+    /// "sdk" (Agent SDK injected), or "system" (system-generated). Verbatim raw
+    /// field — absent on older sessions. See block_accumulator::handlers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_source: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub images: Vec<ImageContent>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -557,6 +562,7 @@ mod tests {
             parent_uuid: None,
             is_sidechain: None,
             agent_id: None,
+            prompt_source: None,
             images: Vec::new(),
             raw_json: None,
         });
@@ -588,6 +594,7 @@ mod tests {
             parent_uuid: None,
             is_sidechain: None,
             agent_id: None,
+            prompt_source: Some("sdk".into()),
             images: Vec::new(),
             raw_json: None,
         };
@@ -600,6 +607,12 @@ mod tests {
         assert_eq!(block.local_id, deserialized.local_id);
         assert_eq!(block.pending, deserialized.pending);
         assert_eq!(block.permission_mode, deserialized.permission_mode);
+        assert_eq!(block.prompt_source, deserialized.prompt_source);
+        // promptSource serializes camelCase and is omitted when None
+        assert_eq!(
+            serde_json::to_value(&block).unwrap()["promptSource"],
+            "sdk"
+        );
     }
 
     #[test]
@@ -615,6 +628,7 @@ mod tests {
             parent_uuid: Some("parent-msg-123".into()),
             is_sidechain: None,
             agent_id: None,
+            prompt_source: None,
             images: Vec::new(),
             raw_json: None,
         };
@@ -638,6 +652,7 @@ mod tests {
             parent_uuid: None,
             is_sidechain: None,
             agent_id: None,
+            prompt_source: None,
             images: Vec::new(),
             raw_json: None,
         };

--- a/packages/shared/src/components/conversation/blocks/chat/UserBlock.tsx
+++ b/packages/shared/src/components/conversation/blocks/chat/UserBlock.tsx
@@ -1,11 +1,16 @@
 import type { UserBlock as UserBlockType } from '../../../../types/blocks'
-import { Bot, Check, GitBranch, Loader2, X } from 'lucide-react'
+import { Bot, Check, Code2, Cog, GitBranch, Loader2, type LucideIcon, X } from 'lucide-react'
 import { useConversationActions } from '../../../../contexts/conversation-actions-context'
 import { MessageTimestamp } from '../shared/MessageTimestamp'
+import { promptSourceDisplay } from '../shared/prompt-source'
 
 interface UserBlockProps {
   block: UserBlockType
 }
+
+// Icon per prompt origin for the chat pill. Unknown future origins fall back
+// to a generic glyph rather than disappearing (Zero Data Loss).
+const SOURCE_ICON: Record<string, LucideIcon> = { sdk: Code2, system: Cog }
 
 function StatusDot({ status }: { status: UserBlockType['status'] }) {
   switch (status) {
@@ -27,6 +32,11 @@ function StatusDot({ status }: { status: UserBlockType['status'] }) {
 export function ChatUserBlock({ block }: UserBlockProps) {
   const convActions = useConversationActions()
   const isSidechain = block.isSidechain === true
+  // Only surface non-default prompt origins (sdk/system). A human-typed prompt
+  // is the expected case and gets no pill — signal over noise.
+  const promptSrc = promptSourceDisplay(block.promptSource)
+  const showSrcPill = promptSrc?.chatVisible === true
+  const SourceIcon = (block.promptSource && SOURCE_ICON[block.promptSource]) || Code2
 
   return (
     <div
@@ -34,13 +44,22 @@ export function ChatUserBlock({ block }: UserBlockProps) {
       className={`flex justify-end ${isSidechain ? 'opacity-70 pl-6' : ''}`}
     >
       <div className="max-w-[80%]">
-        {/* Agent / sidechain badges */}
-        {(block.agentId || isSidechain) && (
+        {/* Agent / sidechain / prompt-origin badges */}
+        {(block.agentId || isSidechain || showSrcPill) && (
           <div className="flex items-center justify-end gap-1.5 mb-1 px-1">
             {isSidechain && (
               <span className="inline-flex items-center gap-0.5 text-xs text-purple-500 dark:text-purple-400">
                 <GitBranch className="w-2.5 h-2.5" />
                 sidechain
+              </span>
+            )}
+            {showSrcPill && promptSrc && (
+              <span
+                className="inline-flex items-center gap-0.5 text-xs font-mono text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/30 px-1.5 py-0.5 rounded-full"
+                title={`Prompt origin: ${promptSrc.label}`}
+              >
+                <SourceIcon className="w-2.5 h-2.5" />
+                {promptSrc.label}
               </span>
             )}
             {block.agentId && (

--- a/packages/shared/src/components/conversation/blocks/developer/UserBlock.tsx
+++ b/packages/shared/src/components/conversation/blocks/developer/UserBlock.tsx
@@ -1,6 +1,7 @@
 import { Check, Loader2, X } from 'lucide-react'
 import type { UserBlock as UserBlockType } from '../../../../types/blocks'
 import { StatusBadge } from '../shared/StatusBadge'
+import { promptSourceDisplay } from '../shared/prompt-source'
 import { MessageTimestamp } from '../shared/MessageTimestamp'
 import { EventCard } from './EventCard'
 import { RENDERED_KEYS as LINEAGE_KEYS, MessageLineageDetail } from './details/MessageLineageDetail'
@@ -30,6 +31,9 @@ function StatusDot({ status }: { status: UserBlockType['status'] }) {
 }
 
 export function DevUserBlock({ block }: UserBlockProps) {
+  // Debug view shows the prompt origin for every value (including the default
+  // "typed") — nothing is low-priority in the developer surface.
+  const promptSrc = promptSourceDisplay(block.promptSource)
   return (
     <EventCard
       dot={block.status === 'failed' ? 'red' : 'blue'}
@@ -41,6 +45,7 @@ export function DevUserBlock({ block }: UserBlockProps) {
       meta={
         <div className="flex items-center gap-1.5">
           {block.agentId && <StatusBadge label={`Agent: ${block.agentId}`} color="indigo" />}
+          {promptSrc && <StatusBadge label={`Source: ${promptSrc.label}`} color={promptSrc.color} />}
           <StatusDot status={block.status} />
         </div>
       }

--- a/packages/shared/src/components/conversation/blocks/shared/StatusBadge.tsx
+++ b/packages/shared/src/components/conversation/blocks/shared/StatusBadge.tsx
@@ -1,4 +1,4 @@
-type BadgeColor =
+export type BadgeColor =
   | 'gray'
   | 'green'
   | 'red'

--- a/packages/shared/src/components/conversation/blocks/shared/prompt-source.test.ts
+++ b/packages/shared/src/components/conversation/blocks/shared/prompt-source.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { promptSourceDisplay } from './prompt-source'
+
+describe('promptSourceDisplay', () => {
+  it('returns null when the field is absent', () => {
+    expect(promptSourceDisplay(undefined)).toBeNull()
+    expect(promptSourceDisplay(null)).toBeNull()
+    expect(promptSourceDisplay('')).toBeNull()
+  })
+
+  it('hides the default human-typed origin from the chat view (signal over noise)', () => {
+    const typed = promptSourceDisplay('typed')
+    expect(typed).not.toBeNull()
+    expect(typed?.chatVisible).toBe(false)
+    expect(typed?.label).toBe('typed')
+  })
+
+  it('surfaces non-default origins (sdk, system) in the chat view', () => {
+    expect(promptSourceDisplay('sdk')).toMatchObject({ label: 'SDK', chatVisible: true })
+    expect(promptSourceDisplay('system')).toMatchObject({ label: 'system', chatVisible: true })
+  })
+
+  it('surfaces unknown future values verbatim rather than dropping them', () => {
+    // Forward-compat: a new CLI prompt origin must not vanish (Zero Data Loss).
+    const future = promptSourceDisplay('voice')
+    expect(future).toMatchObject({ label: 'voice', chatVisible: true })
+  })
+})

--- a/packages/shared/src/components/conversation/blocks/shared/prompt-source.ts
+++ b/packages/shared/src/components/conversation/blocks/shared/prompt-source.ts
@@ -1,0 +1,37 @@
+import type { BadgeColor } from './StatusBadge'
+
+// Display metadata for a Claude Code `promptSource` tag — the verbatim origin
+// of a user prompt: "typed" (human), "sdk" (Agent SDK injected), or "system"
+// (system-generated). This is raw CLI data, not inferred, so surfacing it is
+// trust-safe (no confidence gate needed). Absent on older sessions.
+
+export interface PromptSourceDisplay {
+  /** Human-facing short label. */
+  label: string
+  /**
+   * Whether to surface in the polished chat view. The default human-authored
+   * case ("typed") is hidden as noise — a pill that says "you typed this" on
+   * every message carries no signal. Non-default origins (sdk/system) are the
+   * only ones worth flagging to a reader.
+   */
+  chatVisible: boolean
+  /** Badge tint for the developer (debug) view. */
+  color: BadgeColor
+}
+
+const KNOWN: Record<string, PromptSourceDisplay> = {
+  typed: { label: 'typed', chatVisible: false, color: 'gray' },
+  sdk: { label: 'SDK', chatVisible: true, color: 'cyan' },
+  system: { label: 'system', chatVisible: true, color: 'amber' },
+}
+
+/**
+ * Map a raw `promptSource` value to its display metadata, or `null` when the
+ * field is absent. Unknown future values are surfaced verbatim (Zero Data
+ * Loss) rather than silently dropped — forward-compatible with new CLI prompt
+ * origins a future Claude Code release might introduce.
+ */
+export function promptSourceDisplay(source?: string | null): PromptSourceDisplay | null {
+  if (!source) return null
+  return KNOWN[source] ?? { label: source, chatVisible: true, color: 'gray' }
+}

--- a/packages/shared/src/types/blocks.ts
+++ b/packages/shared/src/types/blocks.ts
@@ -66,6 +66,8 @@ export type UserBlock = {
   parentUuid?: string | null
   isSidechain?: boolean
   agentId?: string
+  /** CC prompt origin: "typed" (human) | "sdk" (Agent SDK) | "system". Absent on older sessions. */
+  promptSource?: string
   images?: ImageContent[]
   rawJson?: Record<string, unknown> | null
 }

--- a/scripts/integrity/evidence-baseline.json
+++ b/scripts/integrity/evidence-baseline.json
@@ -167,9 +167,10 @@
       "forkedFrom.sessionId",
       "forkedFrom.messageUuid",
       "planContent",
-      "entrypoint"
+      "entrypoint",
+      "promptSource"
     ],
-    "consumed_by_parser_note": "Fields previously listed as intentionally_ignored that are now consumed by the block pipeline (TurnBoundary, Notice, UserBlock.permission_mode, forkedFrom, PlanContent, entrypoint).",
+    "consumed_by_parser_note": "Fields previously listed as intentionally_ignored that are now consumed by the block pipeline (TurnBoundary, Notice, UserBlock.permission_mode, forkedFrom, PlanContent, entrypoint, UserBlock.prompt_source). promptSource stays listed under intentionally_ignored (not moved to extracted) because it appears on only a fraction of sessions — keeping it out of the phantom-checked `extracted` set avoids false failures on corpora without recent SDK/system prompts; this array documents that the block pipeline does surface it.",
     "intentionally_ignored": [
       "sessionId",
       "parentUuid",
@@ -269,6 +270,6 @@
       "promptSource",
       "mcpMeta"
     ],
-    "intentionally_ignored_note": "Metadata fields used by Claude Code internally. Either passthrough in SystemBlock.data or not needed by the block pipeline for session display, cost tracking, or live monitoring. attribution* fields (added Claude Code 2.1.123) tag sidechain messages with the dispatching subagent/skill/plugin/mcp-server/mcp-tool — not yet wired into the UI. mode (output-style mode), pendingWorkflowCount (transient session counter) are session metadata not surfaced by the block pipeline. promptSource (prompt-origin metadata) is not surfaced by the block pipeline. mcpMeta is the MCP tool-call metadata envelope — claude-view derives MCP info from the tool_use block itself (message.content[].name) and does not model the envelope; its structuredContent child is opaque tool-defined arbitrary JSON (MCP CallToolResult.structuredContent), so the whole mcpMeta subtree is intentionally ignored by field coverage (prefix match covers all descendants). Surfacing promptSource/mcpMeta is a possible cc-compat follow-up."
+    "intentionally_ignored_note": "Metadata fields used by Claude Code internally. Either passthrough in SystemBlock.data or not needed by the block pipeline for session display, cost tracking, or live monitoring. attribution* fields (added Claude Code 2.1.123) tag sidechain messages with the dispatching subagent/skill/plugin/mcp-server/mcp-tool — not yet wired into the UI. mode (output-style mode), pendingWorkflowCount (transient session counter) are session metadata not surfaced by the block pipeline. promptSource (prompt-origin tag: typed | sdk | system) IS now surfaced — see consumed_by_parser (UserBlock.prompt_source → chat origin pill for sdk/system, developer badge for all values); it stays listed here rather than under `extracted` because it appears on only a fraction of sessions and must not trip the phantom-field check on corpora lacking it. mcpMeta is the MCP tool-call metadata envelope — claude-view derives MCP info from the tool_use block itself (message.content[].name) and does not model the envelope; its structuredContent child is the structured mirror of the tool_result content the timeline already renders, and is opaque tool-defined arbitrary JSON (MCP CallToolResult.structuredContent), so the whole mcpMeta subtree is intentionally ignored by field coverage (prefix match covers all descendants). Decision (settled, not a follow-up): mcpMeta stays unsurfaced — rendering opaque arbitrary per-tool JSON as a structured UI element adds no signal over the already-displayed result and would risk Trust-over-Accuracy."
   }
 }


### PR DESCRIPTION
## What

Claude Code tags each `user` record with a `promptSource` field — the prompt's origin: `typed` (human), `sdk` (Agent SDK injected), or `system` (system-generated). It was parsed away as intentionally-ignored metadata (flagged as a cc-compat follow-up). This surfaces it as a **trust-safe** signal — it's verbatim raw data, not inferred, so no confidence gate is needed.

## Changes

- **core**: extract `promptSource` onto `UserBlock` (both string + array content paths in `block_accumulator/handlers.rs`)
- **chat view**: subtle amber origin pill, shown **only** for `sdk`/`system` — a human-`typed` prompt is the default and gets no pill (signal over noise)
- **developer view**: `Source: <value>` badge for every value (debug = show all)
- **shared `promptSourceDisplay()` helper**: maps origin → label/color/visibility; unknown future origins surface verbatim (Zero Data Loss, forward-compatible)
- **evidence baseline**: document `promptSource` under `consumed_by_parser`; keep it in `intentionally_ignored` (not `extracted`) so the phantom-field check never trips on corpora lacking recent SDK/system prompts (matches the `permissionMode` precedent)
- **mcpMeta**: decision settled (not surfaced) — `structuredContent` is the opaque structured mirror of the `tool_result` content the timeline already renders

## Verification

- `format=block` API serves the field correctly (3 `typed`, 2 `system` on a real session)
- e2e in the running app: chat amber **SDK** pill + dev **Source: SDK** badge render; untagged messages get no pill
- 2158 Rust tests + 371 shared + 2174 web tests green (incl. new parse + helper tests)
- typecheck, clippy `-D warnings`, block-pipeline integrity audit all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)