### PR TITLE
fix(live): dedup recently-closed sessions so the Closed column never doubles

### DIFF
--- a/apps/web/src/store/live-session-store.test.ts
+++ b/apps/web/src/store/live-session-store.test.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest'
-import { useLiveSessionStore, getLastEventTime, type LiveSummary } from './live-session-store'
 import type { LiveSession } from '@claude-view/shared/types/generated'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { type LiveSummary, getLastEventTime, useLiveSessionStore } from './live-session-store'
 
 /** Minimal LiveSession factory — only required fields. */
 function makeSession(id: string): LiveSession {
@@ -197,6 +197,76 @@ describe('useLiveSessionStore', () => {
       await useLiveSessionStore.getState().dismissAllClosed()
 
       expect(useLiveSessionStore.getState().recentlyClosed).toHaveLength(0)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // Regression: duplicate cards in the Closed column.
+  //
+  // A session that is resurrected (re-activated after closing, e.g. a real
+  // `--resume` or a late JSONL flush server-side) and then closes again
+  // produced a SECOND closed card. Root cause: recentlyClosed was treated as
+  // an append log, not a set. "Recently closed" is membership keyed by id:
+  // a session is active XOR closed, and appears in the closed list AT MOST ONCE.
+  // -----------------------------------------------------------------------
+
+  describe('set invariant — closed column has no duplicates', () => {
+    it('handleRemove is idempotent: a session appears in recentlyClosed at most once', () => {
+      const s = makeSession('dup-1')
+      const store = useLiveSessionStore.getState()
+      store.handleRemove('dup-1', s) // close once
+      store.handleRemove('dup-1', s) // resurrected then closed again → second remove
+
+      const closed = useLiveSessionStore.getState().recentlyClosed
+      expect(closed.filter((c) => c.id === 'dup-1')).toHaveLength(1)
+    })
+
+    it('re-close replaces the prior entry (most-recent wins, moved to front)', () => {
+      const store = useLiveSessionStore.getState()
+      store.handleRemove('a', makeSession('a'))
+      store.handleRemove('b', makeSession('b'))
+      // 'a' closes again carrying fresher data.
+      const aNew = { ...makeSession('a'), title: 'a second life' } as LiveSession
+      store.handleRemove('a', aNew)
+
+      const closed = useLiveSessionStore.getState().recentlyClosed
+      expect(closed.filter((c) => c.id === 'a')).toHaveLength(1)
+      expect(closed[0].id).toBe('a') // newest close floats to the top
+      expect(closed.find((c) => c.id === 'a')?.title).toBe('a second life')
+    })
+
+    it('handleUpsert pulls a resumed session back out of recentlyClosed (active XOR closed)', () => {
+      const store = useLiveSessionStore.getState()
+      const s = makeSession('resumed')
+      store.handleRemove('resumed', s) // closed
+      expect(useLiveSessionStore.getState().recentlyClosed.some((c) => c.id === 'resumed')).toBe(
+        true,
+      )
+
+      store.handleUpsert(s) // resumed → active again
+      const state = useLiveSessionStore.getState()
+      expect(state.sessionsById.has('resumed')).toBe(true)
+      expect(state.recentlyClosed.some((c) => c.id === 'resumed')).toBe(false)
+    })
+
+    it('handleSnapshot dedups recentlyClosed by id (truthful boundary normalization)', () => {
+      const dup = makeSession('snap-dup')
+      useLiveSessionStore
+        .getState()
+        .handleSnapshot(emptySummary, [], [dup, makeSession('other'), dup])
+
+      const closed = useLiveSessionStore.getState().recentlyClosed
+      expect(closed.filter((c) => c.id === 'snap-dup')).toHaveLength(1)
+      expect(closed).toHaveLength(2) // snap-dup + other
+    })
+
+    it('handleSnapshot drops a closed id that is also active (active wins)', () => {
+      const both = makeSession('both')
+      useLiveSessionStore.getState().handleSnapshot(emptySummary, [both], [both])
+
+      const state = useLiveSessionStore.getState()
+      expect(state.sessionsById.has('both')).toBe(true)
+      expect(state.recentlyClosed.some((c) => c.id === 'both')).toBe(false)
     })
   })
 })

--- a/apps/web/src/store/live-session-store.ts
+++ b/apps/web/src/store/live-session-store.ts
@@ -1,6 +1,6 @@
+import type { LiveSession } from '@claude-view/shared/types/generated'
 import { useMemo } from 'react'
 import { create } from 'zustand'
-import type { LiveSession } from '@claude-view/shared/types/generated'
 
 export interface LiveSummary {
   needsYouCount: number
@@ -78,9 +78,23 @@ export const useLiveSessionStore = create<LiveSessionState>((set) => ({
       map.set(s.id, s)
       _eventTimes.set(s.id, now)
     }
+    // `recentlyClosed` is a SET keyed by id, disjoint from active sessions.
+    // Defensively normalize the server payload (truthful boundary): drop any id
+    // that is currently active, and keep one entry per id. We walk newest→oldest
+    // (server sends ring order, oldest first) so the most-recent close wins on a
+    // duplicate, then restore oldest→newest order.
+    const seen = new Set<string>()
+    const dedupedClosed: LiveSession[] = []
+    for (let i = recentlyClosed.length - 1; i >= 0; i--) {
+      const s = recentlyClosed[i]
+      if (map.has(s.id) || seen.has(s.id)) continue
+      seen.add(s.id)
+      dedupedClosed.push(s)
+    }
+    dedupedClosed.reverse()
     set({
       sessionsById: map,
-      recentlyClosed,
+      recentlyClosed: dedupedClosed,
       summary,
       isInitialized: true,
       lastUpdateTs: now,
@@ -92,7 +106,14 @@ export const useLiveSessionStore = create<LiveSessionState>((set) => ({
     set((state) => {
       const next = new Map(state.sessionsById)
       next.set(session.id, session)
-      return { sessionsById: next, lastUpdateTs: Date.now() }
+      // A session is active XOR recently-closed, never both. If it was closed
+      // and is now active again (resume / resurrection), pull it back out of the
+      // closed list. The `.some` guard keeps the array reference stable in the
+      // common case (no closed entry) to avoid needless re-renders.
+      const closed = state.recentlyClosed.some((s) => s.id === session.id)
+        ? state.recentlyClosed.filter((s) => s.id !== session.id)
+        : state.recentlyClosed
+      return { sessionsById: next, recentlyClosed: closed, lastUpdateTs: Date.now() }
     })
   },
 
@@ -101,12 +122,13 @@ export const useLiveSessionStore = create<LiveSessionState>((set) => ({
     set((state) => {
       const next = new Map(state.sessionsById)
       next.delete(sessionId)
-      // Prepend to closed list, cap at 100. Avoid spread when at capacity —
-      // splice is O(1) amortized vs spread's O(n) copy.
-      const closed =
-        state.recentlyClosed.length >= 100
-          ? [session, ...state.recentlyClosed.slice(0, 99)]
-          : [session, ...state.recentlyClosed]
+      // `recentlyClosed` is a SET keyed by id. A resurrected session (resumed,
+      // or re-created server-side by a late event) can be reaped twice; without
+      // this dedup the second remove would render a duplicate card. Drop any
+      // existing entry for this id, then prepend the freshest close so the
+      // most-recent close wins and floats to the top. Cap at 100.
+      const deduped = state.recentlyClosed.filter((s) => s.id !== sessionId)
+      const closed = [session, ...deduped].slice(0, 100)
       return { sessionsById: next, recentlyClosed: closed, lastUpdateTs: Date.now() }
     })
   },

--- a/crates/server/src/live/manager/reaper.rs
+++ b/crates/server/src/live/manager/reaper.rs
@@ -78,9 +78,15 @@ impl LiveSessionManager {
             (transcript_path, closed)
         };
 
-        // Phase 1b: Push to bounded ring buffer (FIFO).
+        // Phase 1b: Push to bounded ring buffer (FIFO, set-keyed by id).
         {
             let mut ring = self.closed_ring.write().await;
+            // "Recently closed" is membership keyed by id, not an event log. A
+            // resurrected session (a real `--resume`, or re-created by a late
+            // event) can reach the reaper more than once; drop any prior entry
+            // so a re-close REPLACES it (most-recent wins) and moves it to the
+            // newest slot, instead of duplicating the card in the closed column.
+            ring.retain(|s| s.id != session_id);
             if ring.len() >= crate::live::state::CLOSED_RING_CAPACITY {
                 ring.pop_front(); // evict oldest
             }
@@ -472,6 +478,51 @@ mod tests {
         assert!(
             ring.iter().any(|s| s.id == "ring-1"),
             "ring-1 should survive (only oldest evicted)"
+        );
+    }
+
+    /// Regression (closed-column duplicate cards): a session that is
+    /// resurrected — re-inserted into the live map after being reaped, e.g. a
+    /// real `--resume` or a late JSONL flush — and then reaped again must NOT
+    /// create a second `closed_ring` entry. The ring is a SET keyed by session
+    /// id ("recently closed" is membership, not a log); re-closing REPLACES the
+    /// prior entry (most-recent close wins) and moves it to the newest slot.
+    #[tokio::test]
+    async fn test_resurrection_does_not_duplicate_closed_ring_entry() {
+        let (mgr, _rx, _snap_rx) = make_test_manager().await;
+        let session_id = "sess-resurrect";
+
+        // First life → reap #1.
+        let mut s1 = make_dead_session(session_id, DEAD_PID, "/tmp/res.jsonl");
+        s1.hook.title = "first life".into();
+        mgr.sessions
+            .write()
+            .await
+            .insert(session_id.to_string(), s1);
+        assert_eq!(mgr.reap_session(session_id).await, ReapResult::Reaped);
+
+        // Resurrection: the same id re-enters the live map, then dies again → reap #2.
+        let mut s2 = make_dead_session(session_id, DEAD_PID, "/tmp/res.jsonl");
+        s2.hook.title = "second life".into();
+        mgr.sessions
+            .write()
+            .await
+            .insert(session_id.to_string(), s2);
+        assert_eq!(mgr.reap_session(session_id).await, ReapResult::Reaped);
+
+        // Invariant: the ring holds this id AT MOST ONCE.
+        let ring = mgr.closed_ring.read().await;
+        let matches: Vec<_> = ring.iter().filter(|s| s.id == session_id).collect();
+        assert_eq!(
+            matches.len(),
+            1,
+            "closed_ring must contain a session id at most once (got {})",
+            matches.len()
+        );
+        // ...and the most-recent close wins.
+        assert_eq!(
+            matches[0].hook.title, "second life",
+            "re-close must replace the prior closed-ring entry (most-recent wins)"
         );
     }
 


### PR DESCRIPTION
## Bug
When a session card transitions to **Closed**, it renders **twice** in the Closed column.

Reproduced live (port 47892): the SSE snapshot showed `recentlyClosed` with **25 entries but only 24 unique ids** — session `4d7cdf12` appeared twice, with `closedAt` timestamps **499s apart** (two distinct reaps).

## Root cause — session resurrection + append-only collections
A live session can be **resurrected**: a real `--resume` reuses the same session id, and a late JSONL/hook event can re-create a session that was already reaped (`pipeline.rs` create path has no `closed_ring` guard). It is then reaped **again**.

Both the backend `closed_ring` and the frontend `recentlyClosed` are semantically **SETS keyed by session id** ("recently closed" is membership, not an event log), but both were **append-only with no dedup**. The only ring push site is `reaper.rs`, so two reaps = two entries. The frontend `handleRemove` blind-prepended too. Broadcast + snapshot replay is at-least-once delivery → the handlers must be **idempotent**.

## Fix
**Backend** (`crates/server/src/live/manager/reaper.rs`): ring push is now set-keyed — `retain(|s| s.id != session_id)` before `push_back`, so a re-close **replaces** the prior entry (most-recent wins) and moves it to the newest slot.

**Frontend** (`apps/web/src/store/live-session-store.ts`): enforce "active XOR closed, at most once":
- `handleRemove` — dedup before prepend (idempotent)
- `handleUpsert` — pull a resumed session back out of `recentlyClosed`
- `handleSnapshot` — dedup by id + drop any id that is also active (truthful boundary normalization)

## Verification
| Gate | Result |
|---|---|
| New reaper resurrection test | **RED** (ring=2) → **GREEN** (ring=1, most-recent wins) |
| 5 new store-invariant tests | RED → GREEN |
| Reaper suite / live module | 9 / 297 pass |
| Full web vitest | 2179 pass |
| Full rust-test (pre-push) | 3096 pass |
| clippy · tsc · biome | clean |
| Browser repro (before) | `Closed (25)` for 24 unique — dup confirmed |

Note: the live "collapse" couldn't be re-demoed in-browser because the volatile ring self-evicted that specific dup mid-session; the authoritative verifier for this resurrection-triggered bug is the deterministic test at both layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)