### PR TITLE
feat(live): surface session /goal on live session cards

### DIFF
--- a/apps/web/src/components/live/SessionCard.test.tsx
+++ b/apps/web/src/components/live/SessionCard.test.tsx
@@ -259,3 +259,23 @@ describe('SessionCard interaction display', () => {
     expect(screen.queryByText(/Permission/i)).not.toBeInTheDocument()
   })
 })
+
+// The session's pinned `/goal` (the Stop-hook condition) must surface on the card so
+// you can see what each live session is driving toward — shown ONLY when actually set
+// (寧願唔顯示，都唔顯示錯嘅嘢: better nothing than a wrong/absent goal).
+describe('SessionCard goal', () => {
+  it('renders the goal text when session.goal is set', () => {
+    renderCard(createMockSession({ goal: 'finish the e2e and verify it in prod' }))
+    expect(screen.getByText('finish the e2e and verify it in prod')).toBeInTheDocument()
+  })
+
+  it('does NOT render a goal pill when session.goal is absent', () => {
+    renderCard(createMockSession({ goal: undefined }))
+    expect(screen.queryByText('finish the e2e and verify it in prod')).not.toBeInTheDocument()
+  })
+
+  it('does NOT render a goal pill when session.goal is null', () => {
+    renderCard(createMockSession({ goal: null }))
+    expect(screen.queryByText(/finish the e2e/)).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/live/SessionCard.tsx
+++ b/apps/web/src/components/live/SessionCard.tsx
@@ -17,6 +17,7 @@ import {
   Power,
   Shield,
   Sparkles,
+  Target,
   Terminal,
   TreePine,
 } from 'lucide-react'
@@ -140,6 +141,45 @@ const FILE_KIND_ICON: Record<string, React.ReactNode> = {
   mention: <span className="text-emerald-500 dark:text-emerald-400 font-semibold">@</span>,
   ide: <span className="text-sky-500 dark:text-sky-400">↗</span>,
   pasted: <span className="text-violet-500 dark:text-violet-400">⎘</span>,
+}
+
+/**
+ * The session's pinned `/goal` — the Stop-hook condition the session is driving toward.
+ * Rendered as a single accented banner (distinct from the muted `✦` AI title) with the
+ * full goal text available on hover. Shown only when a goal is set; otherwise nothing.
+ */
+function GoalLine({ goal }: { goal: string }) {
+  const oneLine = cleanPreviewText(goal)
+  if (!oneLine) return null
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger asChild>
+        <div className="flex items-start gap-1.5 mb-1.5 rounded-md border border-indigo-200/80 dark:border-indigo-800/50 bg-indigo-50/60 dark:bg-indigo-950/30 px-2 py-1 cursor-default min-w-0">
+          <Target
+            className="w-3.5 h-3.5 mt-px shrink-0 text-indigo-500 dark:text-indigo-400"
+            aria-hidden="true"
+          />
+          <span className="text-xs font-medium leading-snug text-indigo-700 dark:text-indigo-300 line-clamp-2 min-w-0">
+            {oneLine}
+          </span>
+        </div>
+      </Tooltip.Trigger>
+      <Tooltip.Portal>
+        <Tooltip.Content className={TOOLTIP_CLS} sideOffset={5}>
+          <div className="flex items-start gap-1.5">
+            <Target
+              className="w-3.5 h-3.5 mt-px shrink-0 text-indigo-500 dark:text-indigo-400"
+              aria-hidden="true"
+            />
+            <span className="whitespace-pre-wrap break-words text-gray-900 dark:text-gray-100">
+              {goal}
+            </span>
+          </div>
+          <Tooltip.Arrow className={ARROW_CLS} />
+        </Tooltip.Content>
+      </Tooltip.Portal>
+    </Tooltip.Root>
+  )
 }
 
 function FilesLine({ files }: { files: NonNullable<LiveSession['userFiles']> }) {
@@ -435,6 +475,9 @@ export function SessionCard({
           </span>
         </CostTooltip>
       </div>
+
+      {/* ── Goal (the session's pinned /goal directive) ── */}
+      {session.goal && <GoalLine goal={session.goal} />}
 
       {/* ── AI title ── */}
       {aiTitle && (

--- a/crates/core/src/accumulator/tests.rs
+++ b/crates/core/src/accumulator/tests.rs
@@ -53,6 +53,7 @@ mod tests {
             pasted_paths: Vec::new(),
             entrypoint: None,
             ai_title: None,
+            goal: None,
             content_byte_len: None,
         }
     }

--- a/crates/core/src/live_parser/parse_line.rs
+++ b/crates/core/src/live_parser/parse_line.rs
@@ -70,6 +70,7 @@ pub fn parse_single_line(raw: &[u8], finders: &TailFinders) -> LiveLine {
                 pasted_paths: Vec::new(),
                 entrypoint: None,
                 ai_title: None,
+                goal: None,
                 content_byte_len: None,
             };
         }
@@ -96,6 +97,10 @@ pub fn parse_single_line(raw: &[u8], finders: &TailFinders) -> LiveLine {
             .map(String::from),
         _ => None,
     };
+
+    // Extract the session `/goal` (the session-scoped Stop-hook condition) from whichever
+    // transcript carrier it rode in on. None on the vast majority of lines.
+    let goal = extract_goal(&parsed);
 
     // The nested message object (most fields live here in Claude Code JSONL)
     let msg = parsed.get("message");
@@ -388,7 +393,63 @@ pub fn parse_single_line(raw: &[u8], finders: &TailFinders) -> LiveLine {
         pasted_paths,
         entrypoint,
         ai_title,
+        goal,
         content_byte_len,
+    }
+}
+
+/// Extract the session `/goal` — the session-scoped Stop-hook condition — from a line, if present.
+///
+/// `/goal` writes no file; the goal text rides into the transcript on one of three carriers,
+/// each matched on an exact prefix to keep precision high:
+/// 1. `type:"queue-operation"` → `content`: `"Goal set: <text>"` (typed while the agent is busy)
+/// 2. `type:"attachment"` (`attachment.type:"queued_command"`) → `prompt`: `"Goal set: <text>"`
+///    (auto-continuation re-injection while the goal is still active)
+/// 3. `type:"user"` → `message.content`: `…condition: "<text>". Briefly acknowledge…`
+///    (the universal "Stop hook is now active" directive)
+///
+/// The accumulator keeps the last goal seen, since goals stack / supersede.
+fn extract_goal(parsed: &serde_json::Value) -> Option<String> {
+    const GOAL_SET_PREFIX: &str = "Goal set: ";
+    const HOOK_PREFIX: &str = "A session-scoped Stop hook is now active with condition: \"";
+    const HOOK_SUFFIX: &str = "\". Briefly acknowledge";
+    /// Max stored goal length in chars. Goals are a sentence or two; this only guards
+    /// against a pathological transcript bloating the live-session payload.
+    const MAX_GOAL_CHARS: usize = 2000;
+
+    fn clamp(s: &str) -> Option<String> {
+        let t = s.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.chars().take(MAX_GOAL_CHARS).collect())
+        }
+    }
+
+    match parsed.get("type").and_then(|t| t.as_str()) {
+        Some("queue-operation") => parsed
+            .get("content")
+            .and_then(|c| c.as_str())
+            .and_then(|c| c.strip_prefix(GOAL_SET_PREFIX))
+            .and_then(clamp),
+        Some("attachment") => parsed
+            .get("attachment")
+            .filter(|a| a.get("type").and_then(|t| t.as_str()) == Some("queued_command"))
+            .and_then(|a| a.get("prompt"))
+            .and_then(|p| p.as_str())
+            .and_then(|p| p.strip_prefix(GOAL_SET_PREFIX))
+            .and_then(clamp),
+        Some("user") => {
+            let content = parsed
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(|c| c.as_str())
+                .or_else(|| parsed.get("content").and_then(|c| c.as_str()))?;
+            let rest = content.strip_prefix(HOOK_PREFIX)?;
+            let end = rest.find(HOOK_SUFFIX)?;
+            clamp(&rest[..end])
+        }
+        _ => None,
     }
 }
 

--- a/crates/core/src/live_parser/tests.rs
+++ b/crates/core/src/live_parser/tests.rs
@@ -1265,4 +1265,73 @@ mod tests {
         assert_eq!(parsed.usage_cache_creation_5m_tokens, Some(1000));
         assert_eq!(parsed.usage_cache_creation_1hr_tokens, Some(0));
     }
+
+    // ── `/goal` extraction (the session-scoped Stop-hook condition) ──
+    //
+    // `/goal` writes no file; the goal text lands in the transcript as one of three
+    // carriers. Each is matched on an exact prefix to keep precision high.
+
+    #[test]
+    fn test_goal_from_queue_operation() {
+        // Carrier 1: `/goal` typed while the agent is busy → enqueued.
+        let raw = br#"{"type":"queue-operation","operation":"enqueue","content":"Goal set: finish the e2e and verify it"}"#;
+        let line = parse_single_line(raw, &TailFinders::new());
+        assert_eq!(line.goal.as_deref(), Some("finish the e2e and verify it"));
+    }
+
+    #[test]
+    fn test_goal_from_ismeta_hook_active() {
+        // Carrier 2: the universal "hook is now active" directive (isMeta user message).
+        let raw = br#"{"type":"user","isMeta":true,"message":{"role":"user","content":"A session-scoped Stop hook is now active with condition: \"add the goal feature to the card\". Briefly acknowledge the goal, then immediately start (or continue) working toward it. The hook will block stopping until the condition holds."}}"#;
+        let line = parse_single_line(raw, &TailFinders::new());
+        assert_eq!(
+            line.goal.as_deref(),
+            Some("add the goal feature to the card")
+        );
+    }
+
+    #[test]
+    fn test_goal_from_attachment_queued_command() {
+        // Carrier 3: auto-continuation re-injection while the goal is still active.
+        let raw = br#"{"type":"attachment","attachment":{"type":"queued_command","prompt":"Goal set: ship it","origin":{"kind":"auto-continuation"}}}"#;
+        let line = parse_single_line(raw, &TailFinders::new());
+        assert_eq!(line.goal.as_deref(), Some("ship it"));
+    }
+
+    #[test]
+    fn test_goal_absent_on_normal_user_line() {
+        // Precision: a plain user message that merely contains "Goal set:" is NOT a goal —
+        // only the queue-operation/attachment carriers use that prefix, never raw user text.
+        let raw = br#"{"type":"user","message":{"role":"user","content":"Goal set: this is just me talking about a goal"}}"#;
+        let line = parse_single_line(raw, &TailFinders::new());
+        assert_eq!(line.goal, None);
+    }
+
+    #[test]
+    fn test_goal_absent_when_assistant_quotes_directive() {
+        // Precision: the assistant echoing the directive text must not be mistaken for a goal
+        // (the type gate excludes assistant lines).
+        let raw = br#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"A session-scoped Stop hook is now active with condition: \"x\". Briefly acknowledge"}]}}"#;
+        let line = parse_single_line(raw, &TailFinders::new());
+        assert_eq!(line.goal, None);
+    }
+
+    #[test]
+    fn test_goal_multiline_preserved() {
+        // Goals can span lines (real corpus has `\n`); preserve the text faithfully.
+        let raw = br#"{"type":"queue-operation","operation":"enqueue","content":"Goal set: do A\nthen B"}"#;
+        let line = parse_single_line(raw, &TailFinders::new());
+        assert_eq!(line.goal.as_deref(), Some("do A\nthen B"));
+    }
+
+    #[test]
+    fn test_goal_capped_to_bound_payload() {
+        // A pathologically long goal is clamped so it can't bloat the live-session payload.
+        let long = "x".repeat(5000);
+        let raw = format!(
+            r#"{{"type":"queue-operation","operation":"enqueue","content":"Goal set: {long}"}}"#
+        );
+        let line = parse_single_line(raw.as_bytes(), &TailFinders::new());
+        assert_eq!(line.goal.as_ref().map(|g| g.chars().count()), Some(2000));
+    }
 }

--- a/crates/core/src/live_parser/types.rs
+++ b/crates/core/src/live_parser/types.rs
@@ -182,6 +182,11 @@ pub struct LiveLine {
     pub entrypoint: Option<String>,
     /// AI-generated session title from `ai-title` JSONL lines.
     pub ai_title: Option<String>,
+    /// The session's active `/goal` — the session-scoped Stop-hook condition, if set.
+    /// `/goal` persists no file; the text is written into the transcript via three
+    /// carriers (`queue-operation` "Goal set:", `attachment` queued_command, and the
+    /// `isMeta` "Stop hook is now active" user message). Last-set-wins at the accumulator.
+    pub goal: Option<String>,
     /// Original content byte length before truncation. None if no content extracted.
     pub content_byte_len: Option<usize>,
 }

--- a/crates/server-live-state/src/core.rs
+++ b/crates/server-live-state/src/core.rs
@@ -240,6 +240,7 @@ pub fn test_live_session(id: &str) -> LiveSession {
             source: None,
             phase: PhaseHistory::default(),
             ai_title: None,
+            goal: None,
         },
         session_kind: None,
         entrypoint: None,

--- a/crates/server-live-state/src/jsonl_fields.rs
+++ b/crates/server-live-state/src/jsonl_fields.rs
@@ -90,6 +90,10 @@ pub struct JsonlFields {
     /// AI-generated session title (from `ai-title` JSONL lines).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ai_title: Option<String>,
+    /// The session's active `/goal` — the session-scoped Stop-hook condition, if one is set.
+    /// Extracted from the transcript (no separate file). Absent ⟹ omitted from the payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub goal: Option<String>,
 }
 
 impl Default for JsonlFields {
@@ -118,6 +122,7 @@ impl Default for JsonlFields {
             source: None,
             phase: PhaseHistory::default(),
             ai_title: None,
+            goal: None,
         }
     }
 }

--- a/crates/server/src/live/manager/accumulator.rs
+++ b/crates/server/src/live/manager/accumulator.rs
@@ -155,6 +155,9 @@ pub(crate) struct SessionAccumulator {
     /// AI-generated session title from `ai-title` JSONL lines.
     /// Updated on each occurrence (last one wins).
     pub ai_title: Option<String>,
+    /// The session's active `/goal` (Stop-hook condition) extracted from the transcript.
+    /// Updated on each occurrence (last one wins — goals stack / supersede).
+    pub goal: Option<String>,
 }
 
 impl SessionAccumulator {
@@ -203,6 +206,7 @@ impl SessionAccumulator {
             phase_labels: Vec::new(),
             entrypoint: None,
             ai_title: None,
+            goal: None,
         }
     }
 }
@@ -237,6 +241,7 @@ pub(super) struct JsonlMetadata {
     pub phase: PhaseHistory,
     pub entrypoint: Option<String>,
     pub ai_title: Option<String>,
+    pub goal: Option<String>,
 }
 
 /// Build a skeleton LiveSession from a crash-recovery snapshot entry.
@@ -455,6 +460,11 @@ pub(super) fn apply_jsonl_metadata(
     if m.ai_title.is_some() {
         session.jsonl.ai_title = m.ai_title.clone();
     }
+    // Goal is sticky: only overwrite when the accumulator has a definitive value, so a later
+    // metadata-only poll never blanks out a goal that was already learned.
+    if m.goal.is_some() {
+        session.jsonl.goal = m.goal.clone();
+    }
     // Derive source from JSONL entrypoint (authoritative, no process classification needed)
     if let Some(ref ep) = m.entrypoint {
         let new_source = crate::live::process::entrypoint_to_source(ep);
@@ -554,5 +564,6 @@ pub(super) fn build_metadata_from_accumulator(
         },
         entrypoint: acc.entrypoint.clone(),
         ai_title: acc.ai_title.clone(),
+        goal: acc.goal.clone(),
     }
 }

--- a/crates/server/src/live/manager/line_processor/process_line.rs
+++ b/crates/server/src/live/manager/line_processor/process_line.rs
@@ -109,6 +109,12 @@ impl LiveSessionManager {
             acc.ai_title = Some(title.clone());
         }
 
+        // Track the session `/goal` (Stop-hook condition). Last-set-wins: a newer goal
+        // supersedes an older one, and auto-continuation re-injections keep it fresh.
+        if let Some(ref g) = line.goal {
+            acc.goal = Some(g.clone());
+        }
+
         // Track user messages
         if line.line_type == LineType::User {
             acc.user_turn_count += 1;

--- a/crates/server/src/live/manager/tests.rs
+++ b/crates/server/src/live/manager/tests.rs
@@ -12,7 +12,10 @@ use crate::live::state::{
     SnapshotEntry,
 };
 
-use super::accumulator::{apply_jsonl_metadata, build_recovered_session, JsonlMetadata};
+use super::accumulator::{
+    apply_jsonl_metadata, build_metadata_from_accumulator, build_recovered_session, JsonlMetadata,
+    SessionAccumulator,
+};
 use super::helpers::{
     extract_project_info, extract_session_id, load_session_snapshot,
     load_session_snapshot_from_str, make_synthesized_event, parse_timestamp_to_unix,
@@ -1111,8 +1114,64 @@ fn minimal_jsonl_metadata() -> JsonlMetadata {
         edit_count: 0,
         phase: PhaseHistory::default(),
         ai_title: None,
+        goal: None,
         entrypoint: None,
     }
+}
+
+#[test]
+fn test_build_metadata_carries_goal_from_accumulator() {
+    // Wiring: a goal stored on the accumulator must survive into the JSONL metadata snapshot.
+    let mut acc = SessionAccumulator::new();
+    assert_eq!(acc.goal, None);
+    acc.goal = Some("make the live card show the goal".to_string());
+
+    let meta = build_metadata_from_accumulator(&acc, 0, None);
+    assert_eq!(
+        meta.goal.as_deref(),
+        Some("make the live card show the goal")
+    );
+}
+
+#[test]
+fn test_apply_jsonl_metadata_sets_goal_on_session() {
+    // Wiring: metadata.goal must land on session.jsonl.goal so the card can read it.
+    let mut session = minimal_live_session_for_branch_tests("goal-wiring");
+    assert_eq!(session.jsonl.goal, None);
+
+    let mut meta = minimal_jsonl_metadata();
+    meta.goal = Some("ship the goal feature to the live card".to_string());
+
+    apply_jsonl_metadata(
+        &mut session,
+        &meta,
+        "/tmp/test.jsonl",
+        "proj",
+        "proj",
+        "/tmp/proj",
+    );
+    assert_eq!(
+        session.jsonl.goal.as_deref(),
+        Some("ship the goal feature to the live card")
+    );
+}
+
+#[test]
+fn test_apply_jsonl_metadata_preserves_goal_when_metadata_has_none() {
+    // Stickiness: a metadata-only poll (goal None) must not blank an already-learned goal.
+    let mut session = minimal_live_session_for_branch_tests("goal-sticky");
+    session.jsonl.goal = Some("the original goal".to_string());
+
+    let meta = minimal_jsonl_metadata(); // goal: None
+    apply_jsonl_metadata(
+        &mut session,
+        &meta,
+        "/tmp/test.jsonl",
+        "proj",
+        "proj",
+        "/tmp/proj",
+    );
+    assert_eq!(session.jsonl.goal.as_deref(), Some("the original goal"));
 }
 
 #[test]

--- a/packages/shared/src/types/generated/JsonlFields.ts
+++ b/packages/shared/src/types/generated/JsonlFields.ts
@@ -120,4 +120,9 @@ export type JsonlFields = {
    * AI-generated session title (from `ai-title` JSONL lines).
    */
   aiTitle?: string | null
+  /**
+   * The session's active `/goal` — the session-scoped Stop-hook condition, if one is set.
+   * Extracted from the transcript (no separate file). Absent ⟹ omitted from the payload.
+   */
+  goal?: string | null
 }

--- a/packages/shared/src/types/generated/LiveSession.ts
+++ b/packages/shared/src/types/generated/LiveSession.ts
@@ -378,4 +378,9 @@ export type LiveSession = {
    * AI-generated session title (from `ai-title` JSONL lines).
    */
   aiTitle?: string | null
+  /**
+   * The session's active `/goal` — the session-scoped Stop-hook condition, if one is set.
+   * Extracted from the transcript (no separate file). Absent ⟹ omitted from the payload.
+   */
+  goal?: string | null
 }


### PR DESCRIPTION
## What

The `/goal` slash command pins a **session-scoped Stop-hook condition** ("work until X is done") but it persists **no file** — the goal text only lands in the session JSONL transcript. This surfaces it on the **live monitor cards** so you can see what each running session is driving toward.

## How it works

`/goal` writes the goal into the transcript via three carriers (each matched on an exact prefix for precision):

| Carrier | `type` | Where the text is |
|---|---|---|
| Goal-set event | `queue-operation` | `content` = `"Goal set: <text>"` |
| Hook-active directive (universal) | `user` + `isMeta:true` | `…condition: "<text>". Briefly acknowledge…` |
| Auto-continuation re-inject | `attachment` (`queued_command`) | `prompt` = `"Goal set: <text>"` |

Pipeline mirrors the existing `ai_title` field (last-set-wins):

`extract_goal()` → `LiveLine.goal` → `SessionAccumulator.goal` → `JsonlMetadata.goal` → `LiveSession.jsonl.goal` (sticky: a metadata-only poll never blanks a learned goal) → ts-rs regen (`goal?: string | null`) → `SessionCard` 🎯 pill.

## Trust-gating (寧願唔顯示，都唔顯示錯嘅嘢)

- No goal ⟹ render nothing. There is **no** "goal cleared" marker in the JSONL (auto-clear is in-memory), but a live session with a goal hook **cannot stop until the goal is met**, so on a live card the latest goal is by definition the active directive. The pill is gated to the live monitor.

## Verification

- **Real data e2e:** ran the server against real `~/.claude` — **5/10 live sessions** surfaced their goal via `/api/live/sessions`, including this very PR's own session.
- **UI:** goal pill renders on the live monitor card (🎯 banner above the title, full text on hover).
- **Tests:** parser (3 carriers + 2 precision guards + multiline + 2000-char cap), accumulator wiring (carry / apply / sticky), `SessionCard` (present / absent / null).
- **Gates:** `cq clippy --workspace -D warnings -D deprecated` clean; openapi-drift 154/154; typecheck (9 pkgs) clean; 16 SessionCard vitest + 11 Rust goal tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)