### PR TITLE
data(pricing): add claude-fable-5 and claude-sonnet-5

### DIFF
--- a/data/anthropic-pricing.json
+++ b/data/anthropic-pricing.json
@@ -3,6 +3,18 @@
   "last_verified": "2026-06-02",
   "unit": "usd_per_million_tokens",
   "models": {
+    "claude-fable-5": {
+      "display_name": "Claude Fable 5",
+      "input": 10.0,
+      "output": 50.0,
+      "cache_write_5m": 12.5,
+      "cache_write_1hr": 20.0,
+      "cache_read": 1.0,
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "long_context_pricing": null,
+      "tokenizer_note": "Fable 5 uses the same tokenizer as Opus 4.8; token counts are roughly unchanged vs Opus 4.7/4.8."
+    },
     "claude-opus-4-8": {
       "display_name": "Claude Opus 4.8",
       "input": 5.0,
@@ -37,6 +49,18 @@
       "max_input_tokens": 1000000,
       "max_output_tokens": 128000,
       "long_context_pricing": null
+    },
+    "claude-sonnet-5": {
+      "display_name": "Claude Sonnet 5",
+      "input": 3.0,
+      "output": 15.0,
+      "cache_write_5m": 3.75,
+      "cache_write_1hr": 6.0,
+      "cache_read": 0.3,
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "long_context_pricing": null,
+      "tokenizer_note": "Sonnet 5 uses a new tokenizer (~30% more tokens for the same text vs Sonnet 4.6). Introductory pricing of $2/$10 per MTok applies through 2026-08-31; sticker is $3/$15."
     },
     "claude-sonnet-4-6": {
       "display_name": "Claude Sonnet 4.6",


### PR DESCRIPTION
## What

Adds pricing entries for **`claude-fable-5`** and **`claude-sonnet-5`** to `data/anthropic-pricing.json`.

## Why

These Claude 5-family models were released in July 2026, after the current release (v0.44.0, built 2026-06-03). Because they aren't in the embedded pricing table, sessions that use them show **cost as "Unavailable"** and trigger the `Pricing table drift ... unpriced_models` warning at startup. (`claude-opus-4-8` is already present; only the fable/sonnet-5 aliases were missing.)

The `family-nearest` fallback from #69 doesn't fully cover them — `fable` is a new family with no existing priced sibling to inherit from.

## Values (per 1M tokens, from the Anthropic pricing docs)

| model | input | output | cache read | cache write 5m | cache write 1h |
|---|---|---|---|---|---|
| `claude-fable-5` | $10 | $50 | $1.0 | $12.5 | $20 |
| `claude-sonnet-5` | $3 | $15 | $0.3 | $3.75 | $6 |

Notes captured in `tokenizer_note`:
- Fable 5 shares Opus 4.8's tokenizer.
- Sonnet 5 uses a new tokenizer (~30% more tokens for the same text vs Sonnet 4.6) and has introductory pricing of **$2/$10 through 2026-08-31** (sticker $3/$15).

Both use a 1M context window and 128K max output, so `long_context_pricing` is `null` (no 200K tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)