### PR TITLE
data(pricing): Claude Mythos 5 — new model (limited availability) [ESCALATED, needs review]

### DIFF
--- a/crates/core/src/pricing/loader.rs
+++ b/crates/core/src/pricing/loader.rs
@@ -101,8 +101,8 @@ mod tests {
     #[test]
     fn test_load_pricing_parses_all_models() {
         let pricing = load_pricing();
-        // 19 models + 3 aliases = 22 entries
-        assert_eq!(pricing.len(), 22);
+        // 20 models + 3 aliases = 23 entries
+        assert_eq!(pricing.len(), 23);
     }
 
     /// Models known to appear in real JSONL sessions right now.
@@ -113,6 +113,7 @@ mod tests {
     /// fails with a pointer to the fix.
     const ACTIVE_MODELS: &[&str] = &[
         "claude-fable-5",
+        "claude-mythos-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-opus-4-6",
@@ -178,6 +179,30 @@ mod tests {
         assert!((f.cache_creation_cost_per_token - 12.5e-6).abs() < 1e-15);
         assert!((f.cache_read_cost_per_token - 1e-6).abs() < 1e-15);
         assert!((f.cache_creation_cost_per_token_1hr.unwrap() - 20e-6).abs() < 1e-15);
+    }
+
+    #[test]
+    fn test_mythos_5_priced_at_official_rates() {
+        // Verified against platform.claude.com/docs/.../pricing on 2026-07-08:
+        // Claude Mythos 5 (limited availability, Project Glasswing) is now listed in
+        // the public Model pricing table with rates IDENTICAL to Fable 5 —
+        // $10 in / $50 out / $12.50 5m-cache / $20 1h-cache / $1 read. Mythos is a
+        // distinct family (see lookup::Family::Mythos), so an exact entry is what
+        // prevents "Unavailable" for the exact id; the Family variant covers future
+        // mythos point releases.
+        let pricing = load_pricing();
+        let m = pricing
+            .get("claude-mythos-5")
+            .expect("Mythos 5 must be in the pricing table");
+        assert!((m.input_cost_per_token - 10e-6).abs() < 1e-15);
+        assert!((m.output_cost_per_token - 50e-6).abs() < 1e-15);
+        assert!((m.cache_creation_cost_per_token - 12.5e-6).abs() < 1e-15);
+        assert!((m.cache_read_cost_per_token - 1e-6).abs() < 1e-15);
+        assert!((m.cache_creation_cost_per_token_1hr.unwrap() - 20e-6).abs() < 1e-15);
+        // Identical to Fable 5, as the official table shows.
+        let f = pricing.get("claude-fable-5").unwrap();
+        assert_eq!(m.input_cost_per_token, f.input_cost_per_token);
+        assert_eq!(m.output_cost_per_token, f.output_cost_per_token);
     }
 
     #[test]

--- a/crates/core/src/pricing/lookup.rs
+++ b/crates/core/src/pricing/lookup.rs
@@ -25,6 +25,7 @@ pub fn resolve_model_alias(alias: &str) -> Option<&'static str> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Family {
     Fable,
+    Mythos,
     Opus,
     Sonnet,
     Haiku,
@@ -34,6 +35,7 @@ impl Family {
     fn from_token(token: &str) -> Option<Self> {
         match token {
             "fable" => Some(Family::Fable),
+            "mythos" => Some(Family::Mythos),
             "opus" => Some(Family::Opus),
             "sonnet" => Some(Family::Sonnet),
             "haiku" => Some(Family::Haiku),
@@ -290,6 +292,19 @@ mod tests {
             fable_future.output_cost_per_token,
             fable5.output_cost_per_token
         );
+
+        // Mythos is likewise its own family (limited availability, Project Glasswing).
+        // A future mythos release — or the `claude-mythos-preview` id also named on
+        // the pricing page — must inherit Mythos 5's rate ($10/$50), not "Unavailable".
+        // Before Family::Mythos existed the "mythos" token parsed to no family → None.
+        let mythos_future = lookup_pricing("claude-mythos-6", &pricing)
+            .expect("future mythos release must resolve via family fallback");
+        let mythos5 = pricing.get("claude-mythos-5").unwrap();
+        assert_eq!(
+            mythos_future.input_cost_per_token,
+            mythos5.input_cost_per_token
+        );
+        assert!(lookup_pricing("claude-mythos-preview", &pricing).is_some());
     }
 
     #[test]
@@ -303,6 +318,11 @@ mod tests {
         assert_eq!(
             parse_claude_model("claude-fable-5"),
             Some((Family::Fable, (5, 0)))
+        );
+        // Mythos family (Claude 5, limited availability): distinct from Fable.
+        assert_eq!(
+            parse_claude_model("claude-mythos-5"),
+            Some((Family::Mythos, (5, 0)))
         );
         assert_eq!(
             parse_claude_model("claude-sonnet-4-6"),

--- a/data/anthropic-pricing.json
+++ b/data/anthropic-pricing.json
@@ -1,6 +1,6 @@
 {
   "source": "https://docs.anthropic.com/en/docs/about-claude/pricing",
-  "last_verified": "2026-07-04",
+  "last_verified": "2026-07-08",
   "unit": "usd_per_million_tokens",
   "models": {
     "claude-fable-5": {
@@ -13,7 +13,19 @@
       "max_input_tokens": 1000000,
       "max_output_tokens": 128000,
       "long_context_pricing": null,
-      "tokenizer_note": "Anthropic's most capable widely-released model; prices above Opus tier. Shares Opus 4.8's tokenizer (the Opus 4.7+ tokenizer, ~30% more tokens for the same text vs Sonnet 4.6 and earlier). Full 1M context at a flat rate; 128K max output. Claude Mythos 5 (claude-mythos-5, Project Glasswing limited availability) has identical pricing but is invitation-only and not added here."
+      "tokenizer_note": "Anthropic's most capable widely-released model; prices above Opus tier. Shares Opus 4.8's tokenizer (the Opus 4.7+ tokenizer, ~30% more tokens for the same text vs Sonnet 4.6 and earlier). Full 1M context at a flat rate; 128K max output. Claude Mythos 5 (claude-mythos-5) shares this exact pricing and is listed separately below (limited availability — Project Glasswing)."
+    },
+    "claude-mythos-5": {
+      "display_name": "Claude Mythos 5",
+      "input": 10.0,
+      "output": 50.0,
+      "cache_write_5m": 12.5,
+      "cache_write_1hr": 20.0,
+      "cache_read": 1.0,
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "long_context_pricing": null,
+      "tokenizer_note": "LIMITED AVAILABILITY (invitation-only, Project Glasswing — https://anthropic.com/glasswing). Now listed in the public Model pricing table with identical rates to Claude Fable 5 ($10 in / $50 out, cache 12.5/20/1.0 per MTok); batch $5/$25. Uses the new Opus-4.7+ tokenizer (~30% more tokens for the same text vs Sonnet 4.6 and earlier). Full 1M context at a flat rate; 128K max output. Verified against platform.claude.com/docs/.../pricing on 2026-07-08."
     },
     "claude-opus-4-8": {
       "display_name": "Claude Opus 4.8",


### PR DESCRIPTION
## ⚠️ ESCALATED — needs human review, do NOT auto-merge

`model-pricing-watch` detected a real pricing-page change and prepared this ready-to-merge patch, but the fail-closed confidence gate **escalated** it (see gate below). The rate is verbatim-official and safe; the *decision to surface an invitation-only model* is a product judgement for @tombelieber.

## Source
- **Page:** https://platform.claude.com/docs/en/docs/about-claude/pricing (docs.anthropic.com → platform.claude.com)
- **Fetched:** 2026-07-08 (WebFetch, robust re-extract) + cross-checked vs the detector's 05:00 saved page capture.
- **Detector signal:** flipped `648050e5…` (Jul 4 baseline) → `924f893f…` (Jul 6–8). Headless auto-runs on Jul 6 + Jul 7 died on `API Error: Connection closed mid-response`, so the baseline was left stale (retry-on-next-tick, as designed). This run resolves it.
- **Trigger mechanism:** page grep shows `"Access to Claude Fable 5 and Claude Mythos 5 has been restored"` + a new `<td>Claude Mythos 5 (limited availability)</td>` row — Mythos 5 graduated from prose-only mention into the priced tables.
- **Models API cross-check:** ⚠️ not run — no `ANTHROPIC_API_KEY` / `ant` CLI available in this environment. Id `claude-mythos-5` is taken from the official page table + the page's own anchor `.../introducing-claude-fable-5-and-claude-mythos-5`. **Please confirm the exact API id before merging.**

## Diff vs `data/anthropic-pricing.json` — exactly ONE change

| Model | Base In | 5m Write | 1h Write | Cache Read | Output | Note |
|---|---|---|---|---|---|---|
| **Claude Mythos 5** (NEW) | $10 | $12.50 | $20 | $1 | $50 | limited availability (Project Glasswing) |

Every other row on the page (Fable 5, Opus 4.8/4.7/4.6/4.5/4.1/4, Sonnet 5 intro+sticker, Sonnet 4.6/4.5/4, Haiku 4.5/3.5) matches the embedded table **exactly** — no price changes, no removals.

## Confidence gate → ESCALATE

| # | Condition | Result |
|---|---|---|
| 1 | Structure recognized, ≥6 models matched | ✅ 14 models parsed |
| 2 | Only NEW model / PRICE change (no removal/rewrite) | ✅ one new row |
| 3 | Numeric invariants | ✅ `in $10>0`; `out $50≥in`; `5m 12.50=1.25×10`; `1h 20=2×10`; `read 1=0.1×10` — perfect reconciliation |
| 4 | **No intro/availability qualifier / no family judgement** | ❌ **"limited availability" (invitation-only, Project Glasswing)** + **NEW FAMILY (Mythos)** + **reverses a documented human exclusion** (Fable 5 `tokenizer_note`, 2026-07-04: *"invitation-only and not added here"*) |
| 5 | ci-local green, pricing-only | n/a — escalating |

The price passes every numeric test, but gate #4 fails on three independent counts (any one forces escalation; the skill frontmatter names *"new family judgement"* explicitly). Auto-shipping would fire a full npm release to reverse a human's 4-day-old deliberate exclusion of an invitation-only model — too aggressive.

## What the patch does
- `data/anthropic-pricing.json`: add `claude-mythos-5` (identical rates to Fable 5) + its `tokenizer_note`; update Fable 5's note (it no longer says "not added here"); bump `last_verified` → 2026-07-08.
- `crates/core/src/pricing/lookup.rs`: add `Family::Mythos` variant + `from_token` arm — so the exact id **and** future `claude-mythos-*` / `claude-mythos-preview` ids resolve instead of showing "Unavailable".
- `crates/core/src/pricing/loader.rs`: bump model count 22→23; add `claude-mythos-5` to `ACTIVE_MODELS`; add `test_mythos_5_priced_at_official_rates`.

## Verification
- `./scripts/cq test -p claude-view-core --lib pricing` → **46 passed** (incl. new `test_mythos_5_priced_at_official_rates`, extended family-fallback + parse tests, count test now 23).
- `./scripts/cq clippy -p claude-view-core -- -D warnings` → **clean**.
- Full `ci-local.sh` not run (escalation — human owns the merge/release).

## Reviewer decision
1. **Merge as-is** if invitation-only Mythos 5 should show its real cost for users who have access (correct > "Unavailable").
2. **Close** if invitation-only models should stay "Unavailable" (keeps the 2026-07-04 exclusion).
3. Either way — **confirm the API id `claude-mythos-5`** (no Models-API cross-check was possible here).

If merged, follow the normal `/claude-view-release` (patch) + `/post-release-claude-view`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
