### PR TITLE
fix(pricing): sync tooltip "Rates as of" date + RUSTSEC-2026-0204 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/apps/web/src/components/live/CostTooltip.tsx
+++ b/apps/web/src/components/live/CostTooltip.tsx
@@ -1,10 +1,10 @@
+import type { TeamMemberSidechain } from '@claude-view/shared/types/generated/TeamMemberSidechain'
 import { Minimize2 } from 'lucide-react'
 import { type ReactNode, useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { formatCostUsd, formatTokenCount } from '../../lib/format-utils'
 import { COST_CATEGORY_COLORS } from '../../theme'
 import type { SubAgentInfo } from '../../types/generated/SubAgentInfo'
-import type { TeamMemberSidechain } from '@claude-view/shared/types/generated/TeamMemberSidechain'
 import {
   hasUnavailableCost,
   pricedCoveragePercent,
@@ -257,11 +257,13 @@ export function CostTooltip({
 /**
  * Anthropic pricing verification date.
  *
- * Hardcoded for simplicity — matches the "update manually" philosophy in
- * `data/README.md`. When bumping `last_verified` in `data/anthropic-pricing.json`,
- * update this constant in the same commit.
+ * Hardcoded rather than imported so the whole pricing table doesn't land in the
+ * browser bundle for one date string. The comment alone was not enough — this
+ * silently drifted a month behind `data/anthropic-pricing.json` (showing users
+ * a staler date than the rates actually were), so the pairing is now enforced
+ * by `__tests__/CostTooltip.pricing-date.test.ts`.
  */
-const PRICING_LAST_VERIFIED = '2026-06-02'
+export const PRICING_LAST_VERIFIED = '2026-07-19'
 
 function CostRow({
   label,

--- a/apps/web/src/components/live/__tests__/CostTooltip.pricing-date.test.ts
+++ b/apps/web/src/components/live/__tests__/CostTooltip.pricing-date.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { PRICING_LAST_VERIFIED } from '../CostTooltip'
+
+/**
+ * The tooltip's "Rates as of <date>" is a trust claim shown to users, but the
+ * date is hardcoded in the component while the rates live in the JSON the Rust
+ * binary embeds. Those two drifted a month apart once already. Pin them.
+ */
+describe('CostTooltip pricing date', () => {
+  it('matches last_verified in data/anthropic-pricing.json', () => {
+    // Vitest root is apps/web; the table lives at the repo root. A wrong path
+    // throws rather than silently passing, which is the failure mode we want.
+    const pricingPath = resolve(process.cwd(), '../../data/anthropic-pricing.json')
+    const { last_verified } = JSON.parse(readFileSync(pricingPath, 'utf8'))
+    expect(PRICING_LAST_VERIFIED).toBe(last_verified)
+  })
+})

--- a/data/anthropic-pricing.json
+++ b/data/anthropic-pricing.json
@@ -1,6 +1,6 @@
 {
   "source": "https://docs.anthropic.com/en/docs/about-claude/pricing",
-  "last_verified": "2026-07-04",
+  "last_verified": "2026-07-19",
   "unit": "usd_per_million_tokens",
   "models": {
     "claude-fable-5": {


### PR DESCRIPTION
Fired by the daily `model-pricing-watch` tick. **No model rate changed** — the signal fire was a false positive, and the run instead surfaced two real defects.

## 1. Pricing verification: 0 rate differences

Re-fetched `https://platform.claude.com/docs/en/docs/about-claude/pricing` (2026-07-19) and diffed all 5 columns of every live model against `data/anthropic-pricing.json`:

| Scope | Result |
|---|---|
| 13 live models × (input, 5m cache write, 1h cache write, cache read, output) | **0 differences** |
| Fast-mode table (Opus 4.8 $10/$50, Opus 4.7 $30/$150) | matches `fast_mode` |
| Batch table | matches `batch_discount: 0.5` |
| Sonnet 5 intro $2/$10 through 2026-08-31 → $3/$15 | matches, flip still pending |

Only gap remains `claude-mythos-5` (page: $10/$12.50/$20/$1/$50) — still escalated in #89, deliberately untouched here.

## 2. Defect: tooltip showed a staler date than the rates

`CostTooltip` hardcoded `PRICING_LAST_VERIFIED = '2026-06-02'` while the JSON said `2026-07-04`. The v0.45.0 bump updated the JSON but not the constant, despite the comment instructing it to. Users saw a verification date a month behind reality — a trust claim that was wrong.

Both bumped to `2026-07-19`. The comment demonstrably wasn't enough, so the pairing is now enforced by `CostTooltip.pricing-date.test.ts`, which reads the JSON and asserts the constant matches. Verified both directions — passes as committed, and fails with `expected '2026-06-02' to be '2026-07-19'` when the constant is reverted.

Also applied biome's import-order fix to `CostTooltip.tsx` — pre-existing drift, confirmed present on HEAD before this change (TS lint only runs at release-time ci-local, so main accumulates it).

## 3. Defect: RUSTSEC-2026-0204 blocked every push

`cargo deny check advisories` failed on `crossbeam-epoch 0.9.18` (invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`). Transitive via crossbeam-deque → rayon and metrics-util. Unrelated to the pricing change but blocking all pushes repo-wide. Applied the upstream-recommended `cargo update -p crossbeam-epoch` → 0.9.20; lockfile-only, semver-compatible. Kept as a separate commit so the security bump reviews independently.

## Confidence gate

Classified **COSMETIC** (no `models`-relevant number changed) → ship no rate patch, no release, silent re-baseline. Correct per the skill's fail-closed rule.

## Verification

- 45 Rust pricing tests, 3296 workspace tests, clippy, cargo-deny — all green in the pre-push gate
- 32 `apps/web` tests, `tsc --noEmit`, `biome check` — green
- Detector confirmed quiet after re-baseline: `no pricing-signal change — skipped, 0 tokens`

## Follow-up for a human (not fixed here)

The 7 daily headless runs from 07-11 to 07-18 all died on `Not logged in` / `OAuth session expired and could not be refreshed`. The detector is now correct, but the automation still cannot self-heal until that credential is refreshed — a real price change today would be detected and then silently dropped.