### PR TITLE
feat: build and run natively on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,6 +1004,7 @@ dependencies = [
  "serde_json",
  "tokio-util",
  "ts-rs",
+ "windows-sys 0.60.2",
  "workspace-hack",
 ]
 

--- a/crates/core/src/cli.rs
+++ b/crates/core/src/cli.rs
@@ -62,10 +62,23 @@ impl ClaudeCliStatus {
     /// macOS-specific paths (/opt/homebrew, /Applications) are intentionally excluded.
     /// They are discovered by which_via_shell (step 1 of the waterfall) via the
     /// user's login shell PATH.
+    #[cfg(unix)]
     pub(crate) const KNOWN_CLI_PATHS: &[&str] = &[
         ".local/bin/claude",     // $HOME-relative (XDG)
         "/usr/local/bin/claude", // locally-compiled (FHS)
         "/usr/bin/claude",       // system package (FHS)
+    ];
+
+    /// Known fallback paths for Claude CLI discovery on Windows.
+    ///
+    /// All are `%USERPROFILE%`-relative and point at the real `.exe`, not the
+    /// `claude` / `claude.cmd` shims npm puts on PATH — `std::process::Command`
+    /// goes through CreateProcess, which cannot launch those.
+    #[cfg(windows)]
+    pub(crate) const KNOWN_CLI_PATHS: &[&str] = &[
+        r"AppData\Roaming\npm\node_modules\@anthropic-ai\claude-code\bin\claude.exe",
+        r"AppData\Local\Programs\claude-code\claude.exe",
+        r".local\bin\claude.exe",
     ];
 
     /// Detect Claude CLI installation and status.
@@ -160,6 +173,7 @@ impl ClaudeCliStatus {
     }
 
     /// Resolve `claude` via the server's inherited PATH.
+    #[cfg(unix)]
     fn which_direct() -> Option<String> {
         let output = Self::run_with_timeout(Command::new("which").arg("claude"))?;
         if output.status.success() {
@@ -171,16 +185,43 @@ impl ClaudeCliStatus {
         None
     }
 
+    /// Resolve `claude` via the server's inherited PATH.
+    ///
+    /// ponytail: Windows has no `which` — `where.exe` is the equivalent, and it
+    /// can return several hits (npm ships `claude`, `claude.cmd` and the real
+    /// `.exe`). Only an `.exe` is usable here, because `std::process::Command`
+    /// goes through CreateProcess and cannot launch shell shims. If PATH offers
+    /// nothing but shims, `scan_known_paths` finds the real binary.
+    #[cfg(windows)]
+    fn which_direct() -> Option<String> {
+        let output = Self::run_with_timeout(Command::new("where.exe").arg("claude"))?;
+        if !output.status.success() {
+            return None;
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        stdout
+            .lines()
+            .map(str::trim)
+            .find(|p| p.to_ascii_lowercase().ends_with(".exe") && std::path::Path::new(p).exists())
+            .map(str::to_string)
+    }
+
     /// Scan known installation locations on the filesystem.
     fn scan_known_paths() -> Option<String> {
-        let home = std::env::var("HOME").ok().unwrap_or_default();
+        // Windows has no HOME; fall back to USERPROFILE.
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .unwrap_or_default();
         Self::KNOWN_CLI_PATHS
             .iter()
             .map(|p| {
-                if p.starts_with('/') {
+                if std::path::Path::new(p).is_absolute() {
                     p.to_string()
                 } else {
-                    format!("{home}/{p}")
+                    std::path::Path::new(&home)
+                        .join(p)
+                        .to_string_lossy()
+                        .into_owned()
                 }
             })
             .find(|p| std::path::Path::new(p).exists())
@@ -197,7 +238,14 @@ impl ClaudeCliStatus {
             if trimmed.is_empty() {
                 return None;
             }
-            // Take the last whitespace-separated token as the version
+            // Take the first token that starts with a digit: "2.1.226 (Claude Code)"
+            // → "2.1.226". Falls back to the last token for bare "claude version 1.0.12".
+            if let Some(v) = trimmed
+                .split_whitespace()
+                .find(|t| t.chars().next().is_some_and(|c| c.is_ascii_digit()))
+            {
+                return Some(v.to_string());
+            }
             if let Some(v) = trimmed.split_whitespace().last() {
                 return Some(v.to_string());
             }
@@ -228,10 +276,11 @@ impl ClaudeCliStatus {
     /// when the server runs inside a Claude Code session (the subprocess is
     /// killed before it can produce any output).
     fn check_auth_from_credentials() -> (bool, Option<String>) {
-        let home = match std::env::var("HOME") {
+        // Windows has no HOME; fall back to USERPROFILE.
+        let home = match std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
             Ok(h) => h,
             Err(_) => {
-                tracing::warn!("CLI auth: HOME not set, cannot read credentials");
+                tracing::warn!("CLI auth: neither HOME nor USERPROFILE set, cannot read credentials");
                 return (false, None);
             }
         };

--- a/crates/server-live-state/Cargo.toml
+++ b/crates/server-live-state/Cargo.toml
@@ -15,6 +15,14 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 ts-rs = { workspace = true }
 tokio-util = { workspace = true }
-libc = "0.2"
 claude-view-types = { workspace = true }
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.60", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+] }

--- a/crates/server-live-state/src/classify.rs
+++ b/crates/server-live-state/src/classify.rs
@@ -6,6 +6,7 @@ use super::core::LiveSession;
 ///
 /// Uses `kill(pid, 0)` which checks process existence without sending a signal.
 /// Returns `false` for PIDs <= 1 (kernel/init) to guard against reparented processes.
+#[cfg(unix)]
 pub fn is_pid_alive(pid: u32) -> bool {
     if pid <= 1 {
         return false;
@@ -13,6 +14,35 @@ pub fn is_pid_alive(pid: u32) -> bool {
     // SAFETY: kill with signal 0 does not send a signal, only checks existence.
     // Returns 0 if process exists and we have permission, -1 with ESRCH if not.
     unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+/// Check if a process with the given PID is still alive.
+///
+/// Windows has no `kill(pid, 0)`: open a query handle and ask for the exit code.
+/// `STILL_ACTIVE` (259) means running. Returns `false` for PIDs <= 1.
+#[cfg(windows)]
+pub fn is_pid_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    const STILL_ACTIVE: u32 = 259;
+
+    if pid <= 1 {
+        return false;
+    }
+    // SAFETY: handle is checked for null and always closed before returning.
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return false;
+        }
+        let mut code: u32 = 0;
+        let ok = GetExitCodeProcess(handle, &mut code) != 0;
+        CloseHandle(handle);
+        ok && code == STILL_ACTIVE
+    }
 }
 
 /// What to do with a session that's in the live_sessions map.

--- a/crates/server-sidecar/src/lifecycle.rs
+++ b/crates/server-sidecar/src/lifecycle.rs
@@ -197,13 +197,23 @@ impl SidecarManager {
 
             // Send SIGTERM so Node.js cleanup handlers can run.
             // SAFETY: pid comes from a Child we own; the process exists.
-            let term_result = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
-            if term_result != 0 {
-                tracing::warn!(pid, errno = term_result, "SIGTERM send failed");
+            #[cfg(unix)]
+            {
+                let term_result = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
+                if term_result != 0 {
+                    tracing::warn!(pid, errno = term_result, "SIGTERM send failed");
+                }
             }
 
-            // Poll for graceful exit (up to 3s, 50ms intervals).
-            let deadline = std::time::Instant::now() + Duration::from_secs(3);
+            // ponytail: Windows has no SIGTERM, so there is nothing to wait for —
+            // zero grace period falls straight through to kill() below.
+            #[cfg(unix)]
+            let grace = Duration::from_secs(3);
+            #[cfg(windows)]
+            let grace = Duration::from_secs(0);
+
+            // Poll for graceful exit (50ms intervals).
+            let deadline = std::time::Instant::now() + grace;
             loop {
                 match child.try_wait() {
                     Ok(Some(status)) => {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -22,6 +22,7 @@ pub mod live;
 pub mod local_llm;
 pub use claude_view_server_types::metrics;
 pub mod openapi;
+pub(crate) mod platform;
 pub mod routes;
 pub mod search_service;
 pub mod session_catalog_adapter;

--- a/crates/server/src/live/process.rs
+++ b/crates/server/src/live/process.rs
@@ -80,17 +80,26 @@ pub fn detect_claude_processes() -> (HashMap<u32, ClaudeProcess>, u32) {
         if !is_claude {
             continue;
         }
-        if let Some(cwd) = process.cwd().map(|p| p.to_path_buf()) {
-            total_count += 1;
-            result.insert(
-                pid.as_u32(),
-                ClaudeProcess {
-                    pid: pid.as_u32(),
-                    cwd,
-                    start_time: process.start_time(),
-                },
-            );
-        }
+        // ponytail: Windows does not expose another process's working directory,
+        // so sysinfo returns None there and every Claude process would be dropped.
+        // Keep it with an empty cwd — PID liveness is what the live monitor needs,
+        // and cwd-based project matching falls back to the session file / hook
+        // payload, both of which carry cwd. Upgrade path if that matching matters
+        // on Windows: read the PEB via NtQueryInformationProcess.
+        let cwd = match process.cwd().map(|p| p.to_path_buf()) {
+            Some(cwd) => cwd,
+            None if cfg!(windows) => PathBuf::new(),
+            None => continue,
+        };
+        total_count += 1;
+        result.insert(
+            pid.as_u32(),
+            ClaudeProcess {
+                pid: pid.as_u32(),
+                cwd,
+                start_time: process.start_time(),
+            },
+        );
     }
 
     (result, total_count)
@@ -119,7 +128,8 @@ pub fn count_claude_processes() -> u32 {
         if !is_claude {
             continue;
         }
-        if process.cwd().is_some() {
+        // ponytail: same Windows cwd caveat as detect_claude_processes().
+        if process.cwd().is_some() || cfg!(windows) {
             count += 1;
         }
     }

--- a/crates/server/src/platform.rs
+++ b/crates/server/src/platform.rs
@@ -1,0 +1,80 @@
+//! Cross-platform process termination.
+//!
+//! Routes through `sysinfo` instead of raw `libc::kill` so the server builds and
+//! runs on Windows, where there is no `kill(2)`.
+//!
+//! ponytail: Windows has no SIGTERM. `Process::kill_with(Signal::Term)` returns
+//! `None` there, so graceful termination degrades to the hard kill
+//! (`TerminateProcess`) — the only termination Windows offers. Unix behaviour is
+//! unchanged: SIGTERM for graceful, SIGKILL for forced.
+
+use sysinfo::{Pid, ProcessesToUpdate, Signal, System};
+
+/// Terminate `pid` using an already-refreshed `System`.
+pub(crate) fn terminate_in(sys: &System, pid: u32, force: bool) -> Result<(), String> {
+    let Some(proc) = sys.process(Pid::from_u32(pid)) else {
+        return Err(format!("pid {pid} not found"));
+    };
+    let killed = if force {
+        proc.kill()
+    } else {
+        proc.kill_with(Signal::Term).unwrap_or_else(|| proc.kill())
+    };
+    if killed {
+        Ok(())
+    } else {
+        Err(format!(
+            "{} failed for pid {pid}",
+            if force { "kill" } else { "terminate" }
+        ))
+    }
+}
+
+/// Terminate `pid`, refreshing only that process first.
+pub(crate) fn terminate_pid(pid: u32, force: bool) -> Result<(), String> {
+    let mut sys = System::new();
+    sys.refresh_processes(ProcessesToUpdate::Some(&[Pid::from_u32(pid)]), true);
+    terminate_in(&sys, pid, force)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_pid_reports_not_found() {
+        // PID 0 is never a killable user process on any supported platform.
+        let err = terminate_pid(0, false).unwrap_err();
+        assert!(err.contains("not found"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn terminates_a_real_child_process() {
+        let mut child = if cfg!(windows) {
+            std::process::Command::new("cmd")
+                .args(["/C", "ping -n 30 127.0.0.1 > NUL"])
+                .spawn()
+                .expect("spawn child")
+        } else {
+            std::process::Command::new("sleep")
+                .arg("30")
+                .spawn()
+                .expect("spawn child")
+        };
+
+        terminate_pid(child.id(), true).expect("terminate should succeed");
+
+        // The child must actually die, not just report success.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => break,
+                _ if std::time::Instant::now() >= deadline => {
+                    let _ = child.kill();
+                    panic!("child survived terminate_pid");
+                }
+                _ => std::thread::sleep(std::time::Duration::from_millis(50)),
+            }
+        }
+    }
+}

--- a/crates/server/src/routes/cli_sessions/handlers.rs
+++ b/crates/server/src/routes/cli_sessions/handlers.rs
@@ -396,7 +396,7 @@ pub async fn kill_session(
         let pid_json_exists = dirs::home_dir()
             .map(|h| h.join(format!(".claude/sessions/{pid}.json")).exists())
             .unwrap_or(false);
-        let process_alive = unsafe { libc::kill(pid as i32, 0) } == 0;
+        let process_alive = claude_view_server_live_state::is_pid_alive(pid);
         tracing::debug!(
             tmux_session = %id,
             pane_pid = pid,
@@ -408,8 +408,7 @@ pub async fn kill_session(
         // SIGTERM the Claude CLI process directly — tmux kill only sends SIGHUP
         // which Claude CLI ignores (keeps running its 30s timer).
         if process_alive {
-            let result = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
-            let delivered = result == 0;
+            let delivered = crate::platform::terminate_pid(pid, false).is_ok();
             tracing::debug!(
                 tmux_session = %id,
                 pane_pid = pid,

--- a/crates/server/src/routes/live/actions.rs
+++ b/crates/server/src/routes/live/actions.rs
@@ -38,14 +38,11 @@ pub async fn kill_session(
 
     match session_info {
         Some(Some(pid)) => {
-            let pid_i32 = pid as i32; // safe: macOS PIDs max ~99999, Linux ~4M
-            let result = unsafe { libc::kill(pid_i32, libc::SIGTERM) };
-            if result != 0 {
-                let errno = std::io::Error::last_os_error();
-                tracing::warn!(session_id = %session_id, pid, %errno, "Failed to send SIGTERM");
+            if let Err(err) = crate::platform::terminate_pid(pid, false) {
+                tracing::warn!(session_id = %session_id, pid, %err, "Failed to terminate session process");
                 return (
                     axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "error": format!("SIGTERM failed: {}", errno), "pid": pid })),
+                    Json(serde_json::json!({ "error": err, "pid": pid })),
                 )
                     .into_response();
             }

--- a/crates/server/src/routes/processes.rs
+++ b/crates/server/src/routes/processes.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use sysinfo::{ProcessesToUpdate, System};
 use ts_rs::TS;
 
+use crate::platform::terminate_in;
 use crate::state::AppState;
 
 // =============================================================================
@@ -142,19 +143,13 @@ pub async fn cleanup_processes(
 
         for target in &targets {
             match validate_pid_in_system(&sys, target.pid, target.start_time, own_pid) {
-                Ok(()) => {
-                    let signal = libc::SIGTERM;
-                    let result = unsafe { libc::kill(target.pid as i32, signal) };
-                    if result == 0 {
-                        killed.push(target.pid);
-                    } else {
-                        let errno = std::io::Error::last_os_error();
-                        failed.push(KillFailure {
-                            pid: target.pid,
-                            reason: format!("SIGTERM failed: {errno}"),
-                        });
-                    }
-                }
+                Ok(()) => match terminate_in(&sys, target.pid, false) {
+                    Ok(()) => killed.push(target.pid),
+                    Err(reason) => failed.push(KillFailure {
+                        pid: target.pid,
+                        reason,
+                    }),
+                },
                 Err(reason) => {
                     failed.push(KillFailure {
                         pid: target.pid,
@@ -193,17 +188,7 @@ fn validate_and_kill(pid: u32, start_time: i64, force: bool) -> Result<(), Strin
 
     validate_pid_in_system(&sys, pid, start_time, own_pid)?;
 
-    let signal = if force { libc::SIGKILL } else { libc::SIGTERM };
-    let result = unsafe { libc::kill(pid as i32, signal) };
-    if result == 0 {
-        Ok(())
-    } else {
-        let errno = std::io::Error::last_os_error();
-        Err(format!(
-            "{} failed: {errno}",
-            if force { "SIGKILL" } else { "SIGTERM" }
-        ))
-    }
+    terminate_in(&sys, pid, force)
 }
 
 /// Validate that a PID is safe to kill: exists, start_time matches, not self.

--- a/crates/server/src/startup/serve.rs
+++ b/crates/server/src/startup/serve.rs
@@ -39,13 +39,30 @@ pub async fn run(
         .with_graceful_shutdown(async move {
             // Listen for both SIGINT (Ctrl+C) and SIGTERM (kill, Docker, systemd).
             // Without SIGTERM handling, `kill <pid>` bypasses all cleanup.
+            #[cfg(unix)]
             let mut sigterm =
                 tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
                     .expect("register SIGTERM handler");
 
+            // ponytail: Windows has no SIGTERM. Ctrl+Close (console window closed)
+            // and Ctrl+Break are the equivalents that still let cleanup run.
+            #[cfg(windows)]
+            let mut ctrl_close =
+                tokio::signal::windows::ctrl_close().expect("register ctrl_close handler");
+            #[cfg(windows)]
+            let mut ctrl_break =
+                tokio::signal::windows::ctrl_break().expect("register ctrl_break handler");
+
+            #[cfg(unix)]
             tokio::select! {
                 _ = tokio::signal::ctrl_c() => {}
                 _ = sigterm.recv() => {}
+            }
+            #[cfg(windows)]
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                _ = ctrl_close.recv() => {}
+                _ = ctrl_break.recv() => {}
             }
             eprintln!("\n  Shutting down...");
 
@@ -73,9 +90,17 @@ pub async fn run(
             // Second signal (Ctrl+C or another SIGTERM) skips the wait for
             // impatient users. `sigterm.recv()` is re-armable and cancel-safe —
             // safe to reuse in a second `select!`.
+            #[cfg(unix)]
             tokio::select! {
                 _ = tokio::signal::ctrl_c() => {}
                 _ = sigterm.recv() => {}
+                _ = tokio::time::sleep(std::time::Duration::from_secs(2)) => {}
+            }
+            #[cfg(windows)]
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                _ = ctrl_close.recv() => {}
+                _ = ctrl_break.recv() => {}
                 _ = tokio::time::sleep(std::time::Duration::from_secs(2)) => {}
             }
         })


### PR DESCRIPTION
Makes claude-view build and run natively on Windows. Today the startup platform check rejects it, and several code paths use APIs that do not exist there.

All Unix behaviour is unchanged — every platform difference is behind `cfg` or moves to an existing cross-platform API.

## Process control

- **`server-live-state/classify.rs`** — `is_pid_alive` used `kill(pid, 0)`. Added a Windows implementation via `OpenProcess` + `GetExitCodeProcess`. This is the gate that decides whether a tracked session is live, so without it the live monitor classifies every session as crashed.
- **`server/platform.rs`** (new) — routes termination through `sysinfo`, already a dependency: SIGTERM/SIGKILL on Unix, `TerminateProcess` on Windows. Replaces five raw `libc::kill` sites in `routes/processes.rs`, `routes/live/actions.rs` and `routes/cli_sessions/handlers.rs`.
- **`server-sidecar/lifecycle.rs`** — SIGTERM is now `cfg(unix)`. Windows has no equivalent, so the grace period is zero and shutdown falls through to `kill()` rather than always burning the full 3s.
- **`server/startup/serve.rs`** — `tokio::signal::unix` does not exist on Windows; uses `ctrl_close`/`ctrl_break` alongside `ctrl_c` so hook cleanup and the statusline restore still run.

## Process discovery

- **`server/live/process.rs`** — Claude processes were dropped unless `sysinfo` could read their `cwd`, which Windows does not expose for other processes. `claude.exe` matched the name filter but every match was skipped, so `processCount` stayed 0 and no session ever appeared. They are now kept with an empty `cwd`; cwd-based project matching still works from the session file and hook payloads, which both carry it.

  Upgrade path if that matching ever matters on Windows: read the PEB via `NtQueryInformationProcess`.

## CLI detection

Previously the UI showed *"Claude CLI is not installed. Classification and provider features require it."* even with the CLI installed and authenticated.

- **`core/cli.rs`** — `which` does not exist on Windows. Uses `where.exe` and prefers a real `.exe`: npm puts `claude` and `claude.cmd` shims on PATH first, and `std::process::Command` goes through `CreateProcess`, which cannot launch either.
- Known-path scan and credential lookup fall back to `USERPROFILE` when `HOME` is unset, so auth resolves instead of bailing at `HOME not set`.
- `get_version` took the last whitespace token, turning `2.1.226 (Claude Code)` into `Code)`. Now prefers the first digit-leading token, falling back to the previous behaviour for bare `claude version 1.0.12` output.

  **Note:** this last one is not Windows-specific — it reproduces anywhere `claude --version` prints the parenthesised suffix. Happy to split it into its own PR if you'd rather keep this one platform-only.

## Verification

Built and run on Windows 11 (MSVC 14.51, Windows SDK 10.0.26100, Rust 1.94.1):

- dashboard serves, deep index completed over 283 sessions
- Live Monitor hooks register and fire (`event=PreToolUse state=acting group=Autonomous`)
- `/api/live/sessions` reports `processCount: 3` with live agent state, cost and edit counts
- `/api/system` reports `path`, `version: 2.1.226`, `authenticated: true`, `subscriptionType: max`

`crates/server/src/platform.rs` carries a self-check that spawns a real child process, terminates it, and asserts it actually exits rather than trusting the return value.

Still gated behind `CLAUDE_VIEW_SKIP_PLATFORM_CHECK=1` — I left the startup platform check alone since you may want to keep Windows opt-in until it has more mileage. Say the word and I'll add `windows` to the supported set.

## Not covered

- No CI job for Windows — the repo's CI rules keep gates local, so this follows suit.
- The `dist/` and `sidecar/` layout beside the binary is assembled manually; the release packaging scripts are still macOS/Linux-shaped.
- `cargo test --workspace` was not run on Windows; some pre-existing Unix-only tests are expected to fail there.
