### PR TITLE
data(pricing): Opus 5.5 + Opus 5 + Fable 5.1 — new models; Sonnet 5 intro cancelled [ESCALATED, needs review]

### DIFF
--- a/apps/web/src/components/live/CostTooltip.tsx
+++ b/apps/web/src/components/live/CostTooltip.tsx
@@ -263,7 +263,7 @@ export function CostTooltip({
  * a staler date than the rates actually were), so the pairing is now enforced
  * by `__tests__/CostTooltip.pricing-date.test.ts`.
  */
-export const PRICING_LAST_VERIFIED = '2026-07-19'
+export const PRICING_LAST_VERIFIED = '2026-08-20'
 
 function CostRow({
   label,

--- a/apps/web/src/components/live/CostTooltip.tsx
+++ b/apps/web/src/components/live/CostTooltip.tsx
@@ -263,7 +263,7 @@ export function CostTooltip({
  * a staler date than the rates actually were), so the pairing is now enforced
  * by `__tests__/CostTooltip.pricing-date.test.ts`.
  */
-export const PRICING_LAST_VERIFIED = '2026-08-20'
+export const PRICING_LAST_VERIFIED = '2026-09-02'
 
 function CostRow({
   label,

--- a/crates/core/src/pricing/loader.rs
+++ b/crates/core/src/pricing/loader.rs
@@ -101,8 +101,8 @@ mod tests {
     #[test]
     fn test_load_pricing_parses_all_models() {
         let pricing = load_pricing();
-        // 19 models + 3 aliases = 22 entries
-        assert_eq!(pricing.len(), 22);
+        // 20 models + 3 aliases = 23 entries
+        assert_eq!(pricing.len(), 23);
     }
 
     /// Models known to appear in real JSONL sessions right now.
@@ -113,6 +113,7 @@ mod tests {
     /// fails with a pointer to the fix.
     const ACTIVE_MODELS: &[&str] = &[
         "claude-fable-5",
+        "claude-opus-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-opus-4-6",
@@ -181,12 +182,29 @@ mod tests {
     }
 
     #[test]
-    fn test_sonnet_5_priced_at_introductory_rates() {
-        // Verified against platform.claude.com/docs/.../pricing on 2026-07-04:
-        // Sonnet 5 INTRODUCTORY pricing ($2 in / $10 out / $2.50 5m / $4 1h / $0.20 read)
-        // is in effect through 2026-08-31. This is what sessions are actually billed
-        // right now, so it's what we display — showing the $3/$15 sticker today would
-        // over-report cost by 50%. Flip to sticker on 2026-09-01 (see tokenizer_note).
+    fn test_opus_5_priced_at_official_rates() {
+        // Verified against platform.claude.com/docs/.../pricing on 2026-08-20:
+        // Opus 5 is $5 in / $25 out / $6.25 5m-cache / $10 1h-cache / $0.50 read,
+        // identical to Opus 4.6–4.8. The family fallback would produce the same
+        // value, but an exact entry keeps the displayed cost precise (no estimate).
+        let pricing = load_pricing();
+        let o = pricing
+            .get("claude-opus-5")
+            .expect("Opus 5 must be in the pricing table");
+        assert!((o.input_cost_per_token - 5e-6).abs() < 1e-15);
+        assert!((o.output_cost_per_token - 25e-6).abs() < 1e-15);
+        assert!((o.cache_creation_cost_per_token - 6.25e-6).abs() < 1e-15);
+        assert!((o.cache_read_cost_per_token - 0.5e-6).abs() < 1e-15);
+        assert!((o.cache_creation_cost_per_token_1hr.unwrap() - 10e-6).abs() < 1e-15);
+    }
+
+    #[test]
+    fn test_sonnet_5_priced_at_standard_rates() {
+        // Verified against platform.claude.com/docs/.../pricing on 2026-08-20:
+        // $2 in / $10 out / $2.50 5m / $4 1h / $0.20 read is now the STANDARD
+        // price — Anthropic cancelled the scheduled 2026-09-01 increase to
+        // $3/$15 ("The previously scheduled increase ... will not occur").
+        // Never flip this entry to the old sticker rates.
         let pricing = load_pricing();
         let s = pricing
             .get("claude-sonnet-5")

--- a/crates/core/src/pricing/loader.rs
+++ b/crates/core/src/pricing/loader.rs
@@ -101,8 +101,8 @@ mod tests {
     #[test]
     fn test_load_pricing_parses_all_models() {
         let pricing = load_pricing();
-        // 20 models + 3 aliases = 23 entries
-        assert_eq!(pricing.len(), 23);
+        // 21 models + 3 aliases = 24 entries
+        assert_eq!(pricing.len(), 24);
     }
 
     /// Models known to appear in real JSONL sessions right now.
@@ -112,6 +112,7 @@ mod tests {
     /// list is the CI gate: if a dev forgets the pricing update, the test below
     /// fails with a pointer to the fix.
     const ACTIVE_MODELS: &[&str] = &[
+        "claude-fable-5-1",
         "claude-fable-5",
         "claude-opus-5",
         "claude-opus-4-8",
@@ -162,6 +163,25 @@ mod tests {
             opus48.cache_creation_cost_per_token_1hr,
             opus47.cache_creation_cost_per_token_1hr
         );
+    }
+
+    #[test]
+    fn test_fable_5_1_priced_at_official_rates() {
+        // Verified against platform.claude.com/docs/.../pricing on 2026-09-02:
+        // Fable 5.1 is $10 in / $50 out / $12.50 5m-cache / $20 1h-cache — same as
+        // Fable 5 — EXCEPT cache reads: $0.25 (0.025x base input, a documented
+        // exception that only Fable 5.1 and Mythos 5.1 get; the page footnote says
+        // "priced at 0.025x the base input price"). The family fallback would
+        // inherit Fable 5's $1 read and over-report cache-heavy sessions by 4x.
+        let pricing = load_pricing();
+        let f = pricing
+            .get("claude-fable-5-1")
+            .expect("Fable 5.1 must be in the pricing table");
+        assert!((f.input_cost_per_token - 10e-6).abs() < 1e-15);
+        assert!((f.output_cost_per_token - 50e-6).abs() < 1e-15);
+        assert!((f.cache_creation_cost_per_token - 12.5e-6).abs() < 1e-15);
+        assert!((f.cache_read_cost_per_token - 0.25e-6).abs() < 1e-15);
+        assert!((f.cache_creation_cost_per_token_1hr.unwrap() - 20e-6).abs() < 1e-15);
     }
 
     #[test]

--- a/crates/core/src/pricing/lookup.rs
+++ b/crates/core/src/pricing/lookup.rs
@@ -377,9 +377,10 @@ mod tests {
             "expected newest opus input rate $5/MTok, got {}",
             p.input_cost_per_token * 1e6
         );
-        // Sonnet future inherits the NEWEST sonnet rate. That is now Sonnet 5
-        // ($2/MTok intro through 2026-08-31), which outranks Sonnet 4.6's $3 —
-        // exactly the "nearest preceding, not oldest" guarantee this test names.
+        // Sonnet future inherits the NEWEST sonnet rate. That is Sonnet 5
+        // ($2/MTok, standard price since 2026-08-20 — the scheduled increase to
+        // $3 was cancelled), which outranks Sonnet 4.6's $3 — exactly the
+        // "nearest preceding, not oldest" guarantee this test names.
         let s = lookup_pricing("claude-sonnet-9-9", &pricing).unwrap();
         assert!(
             (s.input_cost_per_token - 2e-6).abs() < 1e-15,

--- a/data/README.md
+++ b/data/README.md
@@ -2,7 +2,7 @@
 
 ## `anthropic-pricing.json`
 
-Static pricing table for Claude models. Embedded into the binary at compile time — no network dependency, no runtime fetch. Verified against [official Anthropic pricing](https://platform.claude.com/docs/en/docs/about-claude/pricing) on 2026-07-04.
+Static pricing table for Claude models. Embedded into the binary at compile time — no network dependency, no runtime fetch. Verified against [official Anthropic pricing](https://platform.claude.com/docs/en/docs/about-claude/pricing) on 2026-08-20.
 
 ### Architecture
 

--- a/data/README.md
+++ b/data/README.md
@@ -2,7 +2,7 @@
 
 ## `anthropic-pricing.json`
 
-Static pricing table for Claude models. Embedded into the binary at compile time — no network dependency, no runtime fetch. Verified against [official Anthropic pricing](https://platform.claude.com/docs/en/docs/about-claude/pricing) on 2026-08-20.
+Static pricing table for Claude models. Embedded into the binary at compile time — no network dependency, no runtime fetch. Verified against [official Anthropic pricing](https://platform.claude.com/docs/en/docs/about-claude/pricing) on 2026-09-02.
 
 ### Architecture
 

--- a/data/anthropic-pricing.json
+++ b/data/anthropic-pricing.json
@@ -1,8 +1,20 @@
 {
   "source": "https://docs.anthropic.com/en/docs/about-claude/pricing",
-  "last_verified": "2026-08-20",
+  "last_verified": "2026-09-02",
   "unit": "usd_per_million_tokens",
   "models": {
+    "claude-fable-5-1": {
+      "display_name": "Claude Fable 5.1",
+      "input": 10.0,
+      "output": 50.0,
+      "cache_write_5m": 12.5,
+      "cache_write_1hr": 20.0,
+      "cache_read": 0.25,
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "long_context_pricing": null,
+      "tokenizer_note": "DOCUMENTED EXCEPTION: cache reads are 0.025x base input ($0.25/MTok), not the standard 0.1x — per the pricing page footnote, only Fable 5.1 and Mythos 5.1 get this rate. Otherwise identical to Fable 5 ($10/$50, writes at the standard multipliers). Reliable knowledge cutoff Jun 2026; full 1M context at a flat rate; 128K max output (300K on Batch API with the output-300k beta header). Claude Mythos 5.1 (claude-mythos-5-1, Project Glasswing limited availability) has identical pricing but is invitation-only and not added here."
+    },
     "claude-fable-5": {
       "display_name": "Claude Fable 5",
       "input": 10.0,
@@ -267,7 +279,7 @@
     "code_execution_free_with_web_search_or_fetch": true,
     "third_party_regional_premium_multiplier": 1.1,
     "third_party_regional_applies_from": "claude-sonnet-4-5-and-later",
-    "notes": "batch_discount applies to both input and output tokens. cache_* multipliers are the standard pattern but Haiku 3 is an exception (1.20x write, 0.12x read vs standard 1.25x/0.1x). Always use per-model rates from the models table for actual cost calculation. Modifiers stack: e.g. fast mode × data residency × cache write multiplier."
+    "notes": "batch_discount applies to both input and output tokens. cache_* multipliers are the standard pattern but there are documented exceptions: Haiku 3 (1.20x write, 0.12x read) and Fable 5.1 / Mythos 5.1 cache reads (0.025x vs standard 0.1x). Always use per-model rates from the models table for actual cost calculation. Modifiers stack: e.g. fast mode × data residency × cache write multiplier."
   },
   "fast_mode": {
     "claude-opus-5": {

--- a/data/anthropic-pricing.json
+++ b/data/anthropic-pricing.json
@@ -1,6 +1,6 @@
 {
   "source": "https://docs.anthropic.com/en/docs/about-claude/pricing",
-  "last_verified": "2026-07-19",
+  "last_verified": "2026-08-20",
   "unit": "usd_per_million_tokens",
   "models": {
     "claude-fable-5": {
@@ -14,6 +14,18 @@
       "max_output_tokens": 128000,
       "long_context_pricing": null,
       "tokenizer_note": "Anthropic's most capable widely-released model; prices above Opus tier. Shares Opus 4.8's tokenizer (the Opus 4.7+ tokenizer, ~30% more tokens for the same text vs Sonnet 4.6 and earlier). Full 1M context at a flat rate; 128K max output. Claude Mythos 5 (claude-mythos-5, Project Glasswing limited availability) has identical pricing but is invitation-only and not added here."
+    },
+    "claude-opus-5": {
+      "display_name": "Claude Opus 5",
+      "input": 5.0,
+      "output": 25.0,
+      "cache_write_5m": 6.25,
+      "cache_write_1hr": 10.0,
+      "cache_read": 0.5,
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "long_context_pricing": null,
+      "tokenizer_note": "Flagship Opus generation (reliable knowledge cutoff May 2026). Full 1M context at a flat rate; 128K max output (300K on Batch API with the output-300k beta header). Fast mode available at $10 in / $50 out (research preview). Same Opus-4.7+ tokenizer."
     },
     "claude-opus-4-8": {
       "display_name": "Claude Opus 4.8",
@@ -60,7 +72,7 @@
       "max_input_tokens": 1000000,
       "max_output_tokens": 128000,
       "long_context_pricing": null,
-      "tokenizer_note": "INTRODUCTORY pricing ($2 in / $10 out, cache 2.5/4/0.2 per MTok) is in effect THROUGH 2026-08-31. From 2026-09-01 the sticker rate is $3 in / $15 out (cache 3.75/6/0.3) — flip this entry to those values on that date. Uses the new Opus-4.7+ tokenizer (~30% more tokens for the same text vs Sonnet 4.6). Full 1M context at a flat rate; 128K max output."
+      "tokenizer_note": "$2 in / $10 out (cache 2.5/4/0.2 per MTok) is the STANDARD price. The launch-intro window was cancelled: per the official pricing page (verified 2026-08-20), the scheduled increase to $3/$15 on 2026-09-01 will NOT occur — never flip this entry to the old sticker rates. Uses the new Opus-4.7+ tokenizer (~30% more tokens for the same text vs Sonnet 4.6). Full 1M context at a flat rate; 128K max output."
     },
     "claude-sonnet-4-6": {
       "display_name": "Claude Sonnet 4.6",
@@ -258,6 +270,13 @@
     "notes": "batch_discount applies to both input and output tokens. cache_* multipliers are the standard pattern but Haiku 3 is an exception (1.20x write, 0.12x read vs standard 1.25x/0.1x). Always use per-model rates from the models table for actual cost calculation. Modifiers stack: e.g. fast mode × data residency × cache write multiplier."
   },
   "fast_mode": {
+    "claude-opus-5": {
+      "input": 10.0,
+      "output": 50.0,
+      "multiplier_vs_base": 2.0,
+      "available": "research_preview",
+      "notes": "Premium fast output across the full 1M context window. Claude API (first-party) only — not available on Claude Platform on AWS or partner platforms, and not with the Batch API. Stacks with prompt caching and data residency multipliers."
+    },
     "claude-opus-4-8": {
       "input": 10.0,
       "output": 50.0,


### PR DESCRIPTION
> **⚠️ ESCALATED — needs human review. Do not merge blind.**
> The pricing changes pass every applicable gate (see Confidence gate), but
> `ci-local.sh` cannot go green on this machine due to **pre-existing,
> unrelated** TS test failures that were A/B-proven on pristine `origin/main`
> (2026-08-20, same 4 files / 50 tests reproduce today — details below).
> Per the model-pricing-watch fail-closed policy, auto-ship stays aborted and
> this PR waits for a human.

## Update 2026-09-23 — Claude Opus 5.5 added (commit `a2ff69ea`) — FIRING #3

Detector fired 2026-09-22 21:06 UTC (signal `1e66ed1a…` ≠ baseline
`8d583665…`). The headless skill invocation died again on the same
`claude-code:unrecognized_model glm-5.3[1m]` bug (ops note in the 09-02
section — still unfixed); a manual `/model-pricing-watch` run on 2026-09-23
processed the change.

1. **NEW model — Claude Opus 5.5** (`claude-opus-5-5`), absent from the embedded
   table. $4 in / $20 out (**cheaper than Opus 5**), cache writes at standard
   multipliers ($5 5m = 1.25× exact, $8 1h = 2× exact), but **cache reads are
   $0.20 (0.05× base input)** — a documented exception:
   > "Cache hits and refreshes on Claude Opus 5.5 are priced at 0.05x the base
   > input price."
   Without an exact entry the family fallback inherits Opus 5's $0.50 read and
   **over-reports cache reads by 2.5×** — same class of exception as Fable 5.1,
   which is why the exact entry is required despite the Opus family existing.
2. **Fast-mode row added**: Opus 5.5 fast mode $8/$40 (research preview, applies
   across the full 1M context incl. >200k requests) — matches the embedded
   `fast_mode` convention (Opus 5 / 4.8 already embedded).
3. `modifiers.notes` updated to record the third documented cache-read
   exception class (0.025× Fable/Mythos 5.1, 0.05× Opus 5.5).
4. All other rates re-verified unchanged. Sonnet 5 $2/$10 standard re-confirmed
   (the "introductory" text on the page only describes the cancelled increase —
   no pending flip, no time-window pricing in this change). Mythos 5 / 5.1
   still excluded (PR #89 convention).

**Model-id cross-check (2026-09-23):** `claude-opus-5-5` confirmed on the
Models overview page (Claude API ID row, pinned dateless snapshot): 1M context,
128K max output, reliable knowledge cutoff Jun 2026, default effort `medium`,
retirement not sooner than **2027-09-22**, Bedrock id `anthropic.claude-opus-5-5`.
Models API (`/v1/models`) still not callable headlessly (no key) — same as
both prior firings.

### Diff table (firing 3, rates USD/MTok)

| Model | Old (JSON) | New (page) | Kind |
|---|---|---|---|
| `claude-opus-5-5` | *(absent — family fallback → Opus 5 $5/$25/$0.50-read)* | $4 in / $20 out / $5 5m / $8 1h / **$0.20 read** | NEW model, 0.05× read exception |
| `fast_mode.claude-opus-5-5` | *(absent)* | $8 / $40, `research_preview` | NEW fast-mode row |
| `last_verified` | 2026-09-02 | 2026-09-23 | bump |

### Confidence gate (firing 3) — ESCALATE maintained

- Structure recognized: full table parsed, 18 rows, ≥6 known models matched ✓
- Change = NEW model only; no removal, no wholesale rewrite ✓
- Invariants: input $4 > 0 ✓; output $20 ≥ input ✓; 5m $5 = 1.25× exact ✓;
  1h $8 = 2× exact ✓; read $0.20 = 0.05× — **documented exception** (page
  footnote 2; same gate treatment as Haiku 3 / Fable 5.1) ✓
- No introductory / time-window pricing **in the change** ✓
- ci-local: **RED — same 4 pre-existing happy-dom files** (4 files / 50 tests,
  `localStorage` undefined; identical signature to the 2026-08-20 A/B proof on
  pristine `origin/main`; this branch touches only 3 pricing files, none of
  them test files) ✗ → **auto-ship stays aborted; human review required**

### Verification (firing 3)

- `./scripts/cq test -p claude-view-core --lib pricing` → **48/48 passed**,
  including new `test_opus_5_5_priced_at_official_rates` and the existing
  `test_all_base_rates_match_official` cross-check.
- `test_load_pricing_parses_all_models` bumped 24 → 25 (22 models + 3 aliases);
  `claude-opus-5-5` added to `ACTIVE_MODELS`.
- No `Family` enum change needed: `parse_claude_model("claude-opus-5-5")` →
  `(Family::Opus, (5, 5))`; family fallback now inherits Opus 5.5 for any
  future `opus-5-6+` point release (nearest-preceding).
- `CostTooltip` `PRICING_LAST_VERIFIED` synced to `2026-09-23` (enforced by
  `CostTooltip.pricing-date.test.ts`, passing).
- Detector baseline re-baselined to `1e66ed1a…` after this run.

## Update 2026-09-02 — Claude Fable 5.1 added (commit `8dbb3d13`)

The detector fired again on 2026-09-01 21:00 UTC (signal `8d583665…` ≠
baseline `3bc4c764…`), but the headless skill invocation **failed to start**
(`claude-code:unrecognized_model glm-5.3[1m]` — ops note below). A manual
`/model-pricing-watch` run on 2026-09-02 processed the change:

1. **NEW model — Claude Fable 5.1** (`claude-fable-5-1`), absent from the
   embedded table. $10 / $50 with cache writes at standard multipliers, but
   **cache reads are $0.25 (0.025× base input)** — a documented exception:
   > "Cache hits and refreshes on Claude Fable 5.1 and Claude Mythos 5.1 are
   > priced at 0.025x the base input price. All other models use the standard
   > 0.1x multiplier."
   Without an exact entry the family fallback inherits Fable 5's $1 read and
   **over-reports cache-heavy sessions by 4×** — this is why the entry matters
   despite identical input/output rates.
2. **Claude Mythos 5.1** also appeared (same rates, Glasswing limited
   availability) — intentionally **not** added, matching the existing Mythos 5
   convention (PR #89 tracks that judgement call).
3. **Sonnet 5 note re-confirmed**: the 2026-09-01 flip date has now PASSED and
   the page still states the increase will not occur — the note fix in this PR
   is now overdue on `main` (anyone following the old embedded instruction
   today would ship wrong prices).
4. Opus 5 rates re-verified unchanged; no other model's rates changed.

**Ops note (skill plumbing):** the daily headless run died with
`claude-code:unrecognized_model {"model":"glm-5.3[1m]"}` before doing any
work — the launchd tick's `--model` string is not accepted by the local
claude binary. Detection itself worked (that's why we know); the skill-side
invocation needs fixing for the automation to be fully hands-off.

## Why this change (original 2026-08-20 run)

Daily pricing-watch tick fired (signal hash changed vs 2026-07-19 baseline).
Re-extraction of the official pricing page found:

1. **NEW model — Claude Opus 5** (`claude-opus-5`), absent from the embedded table.
2. **Sonnet 5 introductory pricing CANCELLED** — the page now states:
   > "The $2/$10 per million input/output token pricing for Claude Sonnet 5,
   > announced at launch as introductory pricing through August 31, 2026, is now
   > the standard price. **The previously scheduled increase to $3/$15 per
   > million input/output tokens on September 1, 2026 will not occur.**"

   Our `tokenizer_note` still instructed flipping the entry to $3/$15 on
   2026-09-01 — executing that flip would have shipped **wrong prices** (the
   exact trust-destroying failure this table exists to prevent). The note and
   the test rationale are corrected; **rates are unchanged** ($2/$10 is what we
   already embed).
3. **Claude Mythos 5** is also on the page — intentionally **not** touched here;
   it remains tracked by open PR #89 (escalated: invitation-only / limited
   availability, human call whether to embed at all).

## Source

- URL: https://platform.claude.com/docs/en/docs/about-claude/pricing
- Fetched: 2026-09-02 via WebFetch (full table + footnotes); detector signal at
  `~/.claude-view/pricing-watch/last-signal.txt` (hash `8d583665…`, fired
  2026-09-01 21:00 UTC).
- Model-id cross-check: Models API unavailable headlessly (no API key / `ant`),
  so ids were verified against the docs **Models overview** page:
  - `claude-opus-5` (Claude API ID row), 1M context, 128K max output, $5/$25,
    retirement not sooner than 2027-07-24.
  - `claude-fable-5-1` (Claude API ID row), 1M context, **128K max output**,
    $10/$50, reliable knowledge cutoff Jun 2026, retirement not sooner than
    2027-09-01. Bedrock id `anthropic.claude-fable-5-1`.
  - `claude-sonnet-5` listed at $2/$10 in the compare table — consistent with
    "standard price" on the pricing page.

## Diff table (all rates USD/MTok)

| Model | Field | Old (JSON) | New (page) | Kind |
|---|---|---|---|---|
| `claude-fable-5-1` | input / output | *(absent)* | $10 / $50 | **NEW** |
| `claude-fable-5-1` | cache 5m / 1h | *(absent)* | $12.50 / $20 | **NEW** |
| `claude-fable-5-1` | cache read | *(absent)* | **$0.25 (0.025×)** | **NEW — documented exception** |
| `claude-opus-5` | input / output | *(absent)* | $5 / $25 | **NEW** |
| `claude-opus-5` | cache 5m / 1h / read | *(absent)* | $6.25 / $10 / $0.50 | **NEW** |
| `claude-sonnet-5` | all 5 rates | $2 / $10 / $2.50 / $4 / $0.20 | identical | unchanged |
| `claude-sonnet-5` | `tokenizer_note` | "flip to $3/$15 on 2026-09-01" | "$2/$10 is standard; increase cancelled — never flip" | note fix |
| `fast_mode.claude-opus-5` | input / output | *(absent)* | $10 / $50 | **NEW** (docs-only section) |
| modifiers `notes` | exceptions list | "Haiku 3 exception" | adds Fable 5.1 / Mythos 5.1 0.025× read | note fix |
| all other page models | all 5 rates | — | byte-identical to JSON | unchanged |

No removals, no numeric changes to any existing model.

## Confidence gate

| Check | Result |
|---|---|
| Page structure recognized | ✅ 17/17 rows matched known models (≥6 required) |
| Change only NEW + note-text (no removal, no wholesale rewrite) | ✅ |
| Opus 5: `input > 0`, `output ≥ input` | ✅ 5 > 0, 25 ≥ 5 |
| Opus 5: `cache_write_5m ≈ 1.25×input` | ✅ 6.25 = 1.25 × 5 (exact) |
| Opus 5: `cache_write_1hr ≈ 2×input` | ✅ 10 = 2 × 5 (exact) |
| Opus 5: `cache_read ≈ 0.1×input` | ✅ 0.50 = 0.1 × 5 (exact) |
| Fable 5.1: `input > 0`, `output ≥ input` | ✅ 10 > 0, 50 ≥ 10 |
| Fable 5.1: `cache_write_5m ≈ 1.25×input` | ✅ 12.50 = 1.25 × 10 (exact) |
| Fable 5.1: `cache_write_1hr ≈ 2×input` | ✅ 20 = 2 × 10 (exact) |
| Fable 5.1: `cache_read ≈ 0.1×input` | ⚠️ 0.25 = **0.025× × 10** — page-footnoted exception (same clause the gate grants Haiku 3); writes still reconcile exactly |
| Introductory / time-window pricing in the change | ✅ **resolved** — the only note is the *cancellation* of a past window; flip date has passed with no increase; nothing time-dated remains |
| ci-local green, pricing files only | ❌ **blocked by unrelated drift → ESCALATE** |

**Classification: ESCALATE** (fail-closed), one remaining reason:

- `ci-local.sh` step 3/10 (TS tests) fails on **4 files / 50 tests** —
  `use-notification-sound`, `monitor-store`, `Banner`, `TakeoverConfirmDialog` —
  all `TypeError: localStorage undefined` under happy-dom. **A/B proof this is
  pre-existing** (2026-08-20): with this branch's changes stashed (pristine
  `origin/main` in the same fresh-install worktree), the same 4 files fail with
  the same 50 failures. The identical signature reproduced on 2026-09-02; the
  four files are untouched by this branch (`git diff ff3cdd16..HEAD` touches
  only the 5 pricing files). Not caused by this patch; not auto-baselined
  (judgement call, per policy).

The original second reason (Sonnet-5 intro-topic tripwire) is **cleared as of
2026-09-02**: the window closed with the cancellation confirmed on the page,
so there is no longer any future-dated pricing decision embedded in this PR.

## Verification (what IS green)

- `./scripts/cq test -p claude-view-core --lib pricing` → **47/47 pass**
  (2026-09-02), including `test_fable_5_1_priced_at_official_rates`,
  `test_opus_5_priced_at_official_rates`, `test_sonnet_5_priced_at_standard_rates`,
  `test_all_active_models_priced`, `test_load_pricing_parses_all_models` (24).
- `./scripts/cq clippy -p claude-view-core --lib -- -D warnings` → clean
  (2026-08-20; loader/lookup unchanged in kind since).
- `CostTooltip.pricing-date.test.ts` → **pass** (2026-09-02; JSON
  `last_verified` ↔ UI "Rates as of" sync enforced at 2026-09-02).
- ci-local steps 1–2 (biome lint, typecheck) → green.
- Pre-push gate (lefthook: workspace clippy, cargo-deny, `cq test --workspace`)
  — **could not complete** on this machine (2026-08-20): the pre-push test
  scripts leak `GIT_*` env from `git push` and their synthetic-repo fixtures
  commit into the REAL repo (two junk commits `c1`/`c2` had to be reset off
  this branch; see comment). The 2026-09-02 push completed cleanly without
  junk commits (remote verified `8dbb3d13`), but the leak is untested-but-not-
  fixed — reviewer should run `./scripts/cq clippy --workspace -- -D warnings`
  and `./scripts/cq test --workspace` before merging.
- Family-fallback notes: even *without* this patch, `claude-opus-5` sessions
  priced correctly via Opus-family nearest-version fallback (identical $5/$25);
  the exact entry upgrades the match from `FamilyFallback` to `Exact`.
  `claude-fable-5-1` would fall back to Fable 5 rates — correct except cache
  read ($1 vs $0.25, 4× over-report), which is why its exact entry is required.

## Files changed (5, across both commits)

- `data/anthropic-pricing.json` — fable-5-1 + opus-5 entries, sonnet-5 note,
  fast_mode opus-5 entry, modifiers exceptions note, `last_verified` → 2026-09-02
- `crates/core/src/pricing/loader.rs` — count 22→24, `ACTIVE_MODELS` +
  `claude-fable-5-1` + `claude-opus-5`, exact-rate regression tests ×2,
  sonnet-5 test rename/comment
- `crates/core/src/pricing/lookup.rs` — comment-only (intro wording in a test)
- `apps/web/src/components/live/CostTooltip.tsx` — `PRICING_LAST_VERIFIED` → 2026-09-02
- `data/README.md` — verified date

No `Family` enum change (Fable and Opus families already exist in `from_token`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Raw diff — commit `8dbb3d13` (2026-09-02, fable-5-1)

```diff
diff --git a/apps/web/src/components/live/CostTooltip.tsx b/apps/web/src/components/live/CostTooltip.tsx
index 43e4faf2..1c777dd2 100644
--- a/apps/web/src/components/live/CostTooltip.tsx
+++ b/apps/web/src/components/live/CostTooltip.tsx
@@ -263,7 +263,7 @@ export function CostTooltip({
  * a staler date than the rates actually were), so the pairing is now enforced
  * by `__tests__/CostTooltip.pricing-date.test.ts`.
  */
-export const PRICING_LAST_VERIFIED = '2026-08-20'
+export const PRICING_LAST_VERIFIED = '2026-09-02'
 
 function CostRow({
   label:
diff --git a/crates/core/src/pricing/loader.rs b/crates/core/src/pricing/loader.rs
index 48beebed..7e5c68c1 100644
--- a/crates/core/src/pricing/loader.rs
+++ b/crates/core/src/pricing/loader.rs
@@ -101,8 +101,8 @@ mod tests {
     #[test]
     fn test_load_pricing_parses_all_models() {
         let pricing = load_pricing();
-        // 20 models + 3 aliases = 23 entries
-        assert_eq!(pricing.len(), 23);
+        // 21 models + 3 aliases = 24 entries
+        assert_eq!(pricing.len(), 24);
     }
 
     /// Models known to appear in real JSONL sessions right now.
@@ -113,6 +113,7 @@ mod tests {
     /// fails with a pointer to the fix.
     const ACTIVE_MODELS: &[&str] = &[
+        "claude-fable-5-1",
         "claude-fable-5",
         "claude-opus-5",
         "claude-opus-4-8",
@@ -181,12 +182,29 @@ mod tests {
     }
 
     #[test]
+    fn test_fable_5_1_priced_at_official_rates() {
+        // Verified against platform.claude.com/docs/.../pricing on 2026-09-02:
+        // Fable 5.1 is $10 in / $50 out / $12.50 5m-cache / $20 1h-cache — same as
+        // Fable 5 — EXCEPT cache reads: $0.25 (0.025x base input, a documented
+        // exception that only Fable 5.1 and Mythos 5.1 get; the page footnote says
+        // "priced at 0.025x the base input price"). The family fallback would
+        // inherit Fable 5's $1 read and over-report cache-heavy sessions by 4x.
+        let pricing = load_pricing();
+        let f = pricing
+            .get("claude-fable-5-1")
+            .expect("Fable 5.1 must be in the pricing table");
+        assert!((f.input_cost_per_token - 10e-6).abs() < 1e-15);
+        assert!((f.output_cost_per_token - 50e-6).abs() < 1e-15);
+        assert!((f.cache_creation_cost_per_token - 12.5e-6).abs() < 1e-15);
+        assert!((f.cache_read_cost_per_token - 0.25e-6).abs() < 1e-15);
+        assert!((f.cache_creation_cost_per_token_1hr.unwrap() - 20e-6).abs() < 1e-15);
+    }
+
+    #[test]
     fn test_fable_5_priced_at_official_rates() {
```

*(abbreviated — full commit diff at `8dbb3d13`; the JSON hunk adds the
`claude-fable-5-1` entry with `cache_read: 0.25` + exception note, extends the
modifiers `notes` exception list, and bumps `last_verified` / README /
CostTooltip dates to 2026-09-02.)*

## Raw diff — commit `233e6fd8` (2026-08-20, opus-5 + sonnet-5 note)

```diff
diff --git a/apps/web/src/components/live/CostTooltip.tsx b/apps/web/src/components/live/CostTooltip.tsx
index c7ecbfa0..43e4faf2 100644
--- a/apps/web/src/components/live/CostTooltip.tsx
+++ b/apps/web/src/components/live/CostTooltip.tsx
@@ -263,7 +263,7 @@ export function CostTooltip({
  * a staler date than the rates actually were), so the pairing is now enforced
  * by `__tests__/CostTooltip.pricing-date.test.ts`.
  */
-export const PRICING_LAST_VERIFIED = '2026-07-19'
+export const PRICING_LAST_VERIFIED = '2026-08-20'
 
 function CostRow({
   label:
diff --git a/crates/core/src/pricing/loader.rs b/crates/core/src/pricing/loader.rs
index c1b82b2b..48beebed 100644
--- a/crates/core/src/pricing/loader.rs
+++ b/crates/core/src/pricing/loader.rs
@@ -101,8 +101,8 @@ mod tests {
     #[test]
     fn test_load_pricing_parses_all_models() {
         let pricing = load_pricing();
-        // 19 models + 3 aliases = 22 entries
-        assert_eq!(pricing.len(), 22);
+        // 20 models + 3 aliases = 23 entries
+        assert_eq!(pricing.len(), 23);
     }
 
     /// Models known to appear in real JSONL sessions right now.
@@ -113,6 +113,7 @@ mod tests {
     /// fails with a pointer to the fix.
     const ACTIVE_MODELS: &[&str] = &[
         "claude-fable-5",
+        "claude-opus-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-opus-4-6",
@@ -181,12 +182,29 @@ mod tests {
     }
 
     #[test]
-    fn test_sonnet_5_priced_at_introductory_rates() {
-        // Verified against platform.claude.com/docs/.../pricing on 2026-07-04:
-        // Sonnet 5 INTRODUCTORY pricing ($2 in / $10 out / $2.50 5m / $4 1h / $0.20 read)
-        // is in effect through 2026-08-31. This is what sessions are actually billed
-        // right now, so it's what we display — showing the $3/$15 sticker today would
-        // over-report cost by 50%. Flip to sticker on 2026-09-01 (see tokenizer_note).
+    fn test_opus_5_priced_at_official_rates() {
+        // Verified against platform.claude.com/docs/.../pricing on 2026-08-20:
+        // Opus 5 is $5 in / $25 out / $6.25 5m-cache / $10 1h-cache / $0.50 read,
+        // identical to Opus 4.6–4.8. The family fallback would produce the same
+        // value, but an exact entry keeps the displayed cost precise (no estimate).
+        let pricing = load_pricing();
+        let o = pricing
+            .get("claude-opus-5")
+            .expect("Opus 5 must be in the pricing table");
+        assert!((o.input_cost_per_token - 5e-6).abs() < 1e-15);
+        assert!((o.output_cost_per_token - 25e-6).abs() < 1e-15);
+        assert!((o.cache_creation_cost_per_token - 6.25e-6).abs() < 1e-15);
+        assert!((o.cache_read_cost_per_token - 0.5e-6).abs() < 1e-15);
+        assert!((o.cache_creation_cost_per_token_1hr.unwrap() - 10e-6).abs() < 1e-15);
+    }
+
+    #[test]
+    fn test_sonnet_5_priced_at_standard_rates() {
+        // Verified against platform.claude.com/docs/.../pricing on 2026-08-20:
+        // $2 in / $10 out / $2.50 5m / $4 1h / $0.20 read is now the STANDARD
+        // price — Anthropic cancelled the scheduled 2026-09-01 increase to
+        // $3/$15 ("The previously scheduled increase ... will not occur").
+        // Never flip this entry to the old sticker rates.
         let pricing = load_pricing();
         let s = pricing
             .get("claude-sonnet-5")
diff --git a/crates/core/src/pricing/lookup.rs b/crates/core/src/pricing/lookup.rs
index 715b11bf..04391399 100644
--- a/crates/core/src/pricing/lookup.rs
+++ b/crates/core/src/pricing/lookup.rs
@@ -377,9 +377,10 @@ mod tests {
             "expected newest opus input rate $5/MTok, got {}",
             p.input_cost_per_token * 1e6
         );
-        // Sonnet future inherits the NEWEST sonnet rate. That is now Sonnet 5
-        // ($2/MTok intro through 2026-08-31), which outranks Sonnet 4.6's $3 —
-        // exactly the "nearest preceding, not oldest" guarantee this test names.
+        // Sonnet future inherits the NEWEST sonnet rate. That is Sonnet 5
+        // ($2/MTok, standard price since 2026-08-20 — the scheduled increase to
+        // $3 was cancelled), which outranks Sonnet 4.6's $3 — exactly the
+        // "nearest preceding, not oldest" guarantee this test names.
         let s = lookup_pricing("claude-sonnet-9-9", &pricing).unwrap();
         assert!(
             (s.input_cost_per_token - 2e-6).abs() < 1e-15,
diff --git a/data/README.md b/data/README.md
index 0b45cadd..6d5b97dd 100644
--- a/data/README.md
+++ b/data/README.md
@@ -2,7 +2,7 @@
 
 ## `anthropic-pricing.json`
 
-Static pricing table for Claude models. Embedded into the binary at compile time — no network dependency, no runtime fetch. Verified against [official Anthropic pricing](https://platform.claude.com/docs/en/docs/about-claude/pricing) on 2026-07-04.
+Static pricing table for Claude models. Embedded into the binary at compile time — no network dependency, no runtime fetch. Verified against [official Anthropic pricing](https://platform.claude.com/docs/en/docs/about-claude/pricing) on 2026-08-20.
 
 ### Architecture:
diff --git a/data/anthropic-pricing.json b/data/anthropic-pricing.json
index 75d8f3ea..1655743c 100644
--- a/data/anthropic-pricing.json
+++ b/data/anthropic-pricing.json
@@ -1,6 +1,6 @@
 {
   "source": "https://docs.anthropic.com/en/docs/about-claude/pricing",
-  "last_verified": "2026-07-19",
+  "last_verified": "2026-08-20",
   "unit": "usd_per_million_tokens",
   "models": {
     "claude-fable-5": {
@@ -15,6 +15,18 @@
       "long_context_pricing": null,
       "tokenizer_note": "Anthropic's most capable widely-released model; prices above Opus tier. Shares Opus 4.8's tokenizer (the Opus 4.7+ tokenizer, ~30% more tokens for the same text vs Sonnet 4.6 and earlier). Full 1M context at a flat rate; 128K max output. Claude Mythos 5 (claude-mythos-5, Project Glasswing limited availability) has identical pricing but is invitation-only and not added here."
     },
+    "claude-opus-5": {
+      "display_name": "Claude Opus 5",
+      "input": 5.0,
+      "output": 25.0,
+      "cache_write_5m": 6.25,
+      "cache_write_1hr": 10.0,
+      "cache_read": 0.5,
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "long_context_pricing": null,
+      "tokenizer_note": "Flagship Opus generation (reliable knowledge cutoff May 2026). Full 1M context at a flat rate; 128K max output (300K on Batch API with the output-300k beta header). Fast mode available at $10 in / $50 out (research preview). Same Opus-4.7+ tokenizer."
+    },
     "claude-opus-4-8": {
       "display_name": "Claude Opus 4.8",
       "input": 5.0,
@@ -60,7 +72,7 @@
       "max_input_tokens": 1000000,
       "max_output_tokens": 128000,
       "long_context_pricing": null,
-      "tokenizer_note": "INTRODUCTORY pricing ($2 in / $10 out, cache 2.5/4/0.2 per MTok) is in effect THROUGH 2026-08-31. From 2026-09-01 the sticker rate is $3 in / $15 out (cache 3.75/6/0.3) — flip this entry to those values on that date. Uses the new Opus-4.7+ tokenizer (~30% more tokens for the same text vs Sonnet 4.6). Full 1M context at a flat rate; 128K max output."
+      "tokenizer_note": "$2 in / $10 out (cache 2.5/4/0.2 per MTok) is the STANDARD price. The launch-intro window was cancelled: per the official pricing page (verified 2026-08-20), the scheduled increase to $3/$15 on 2026-09-01 will NOT occur — never flip this entry to the old sticker rates. Uses the new Opus-4.7+ tokenizer (~30% more tokens for the same text vs Sonnet 4.6). Full 1M context at a flat rate; 128K max output."
     },
     "claude-sonnet-4-6": {
       "display_name": "Claude Sonnet 4.6",
@@ -258,6 +270,13 @@
     "notes": "batch_discount applies to both input and output tokens. cache_* multipliers are the standard pattern but Haiku 3 is an exception (1.20x write, 0.12x read vs standard 1.25x/0.1x). Always use per-model rates from the models table for actual cost calculation. Modifiers stack: e.g. fast mode × data residency × cache write multiplier."
   },
   "fast_mode": {
+    "claude-opus-5": {
+      "input": 10.0,
+      "output": 50.0,
+      "multiplier_vs_base": 2.0,
+      "available": "research_preview",
+      "notes": "Premium fast output across the full 1M context window. Claude API (first-party) only — not available on Claude Platform on AWS or partner platforms, and not with the Batch API. Stacks with prompt caching and data residency multipliers."
+    },
     "claude-opus-4-8": {
       "input": 10.0,
       "output": 50.0,
```

